### PR TITLE
[1.3] Makes `broker` and `topic` argument optional, add `assertPublishedTimes` and `assertPublishedOnTimes` and make message argument optional for assertion methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All relevant changes to `mateusjunges/laravel-kafka` will be documented here.
 
+## [2020-11-12 v1.3.0](https://github.com/mateusjunges/laravel-kafka/compare/v1.2.0...v1.3.0)
+### Changed
+- Make topic name optional. Add method to set topic name when using fake driver ([#12dde5](https://github.com/mateusjunges/laravel-kafka/commit/12dde5de2aa8b9d735fa3fb093dc48948733f3a3), [#8f5b25](https://github.com/mateusjunges/laravel-kafka/commit/8f5b258609cbd6f475aee4e9a9517daeffcd5b60), [#f3c8b43](https://github.com/mateusjunges/laravel-kafka/commit/f3c8b4392872063060891bc9f2152712b639e81b), [#fe19922](https://github.com/mateusjunges/laravel-kafka/commit/fe199227fd1b657660d30fb7fc0cca41d5a4d24f))
+- Make broker parameter optional ([#5625bef](https://github.com/mateusjunges/laravel-kafka/commit/5625befca0c11ae19b109f1368d42d5aaa284da2), [#aa5596c](https://github.com/mateusjunges/laravel-kafka/commit/aa5596c21910bae780e9f4be8afb5864a6b8eab7), [#c6ad0e9](https://github.com/mateusjunges/laravel-kafka/commit/c6ad0e98ee65536d30a09bdaeb89c3e184860f07), [#5117cd8](https://github.com/mateusjunges/laravel-kafka/commit/5117cd8eeb435ab1774144cca1ef6ed36b0d09d7))
+- Allow getTopicName to return null on KafkaMessage contract ([#3e6289d](https://github.com/mateusjunges/laravel-kafka/commit/3e6289d91cf36bdc185eb142810b1dffe463df6f))
+- Make topicName optional on Message::create() ([#7213af9](https://github.com/mateusjunges/laravel-kafka/commit/7213af9b6fc843301d8ffc84e961387d118fde37))
+- Fix `publishOn` and `createConsumer` method signatures on kafka facade ([#eb66e8e](https://github.com/mateusjunges/laravel-kafka/commit/eb66e8efa1a94be020193017dd9ea2f1025c41e9))
+
+
 ## [2021-11-08 v1.2.0](https://github.com/mateusjunges/laravel-kafka/compare/v1.1.3...v1.2.0)
 ### Added
 - Added the security protocol to Sasl class. By default, its used `SASL_PLAINTEXT`([#f4e62d2](https://github.com/mateusjunges/laravel-kafka/commit/f4e62d2d5e8d2842ccd3168295245a911f5f74fb))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,16 @@
 All relevant changes to `mateusjunges/laravel-kafka` will be documented here.
 
 ## [2020-11-14 v1.3.0](https://github.com/mateusjunges/laravel-kafka/compare/v1.2.0...v1.3.0)
+### Added
+- Added `assertPublishedTimes` and `assertPublishedOnTimes` methods ([#a16a10d](https://github.com/mateusjunges/laravel-kafka/commit/a16a10dbe9ddfbbe5e412148b2083faead774cf8))
+
 ### Changed
 - Make topic name optional. Add method to set topic name when using fake driver ([#12dde5](https://github.com/mateusjunges/laravel-kafka/commit/12dde5de2aa8b9d735fa3fb093dc48948733f3a3), [#8f5b25](https://github.com/mateusjunges/laravel-kafka/commit/8f5b258609cbd6f475aee4e9a9517daeffcd5b60), [#f3c8b43](https://github.com/mateusjunges/laravel-kafka/commit/f3c8b4392872063060891bc9f2152712b639e81b), [#fe19922](https://github.com/mateusjunges/laravel-kafka/commit/fe199227fd1b657660d30fb7fc0cca41d5a4d24f))
 - Make broker parameter optional ([#5625bef](https://github.com/mateusjunges/laravel-kafka/commit/5625befca0c11ae19b109f1368d42d5aaa284da2), [#aa5596c](https://github.com/mateusjunges/laravel-kafka/commit/aa5596c21910bae780e9f4be8afb5864a6b8eab7), [#c6ad0e9](https://github.com/mateusjunges/laravel-kafka/commit/c6ad0e98ee65536d30a09bdaeb89c3e184860f07), [#5117cd8](https://github.com/mateusjunges/laravel-kafka/commit/5117cd8eeb435ab1774144cca1ef6ed36b0d09d7))
 - Allow getTopicName to return null on KafkaMessage contract ([#3e6289d](https://github.com/mateusjunges/laravel-kafka/commit/3e6289d91cf36bdc185eb142810b1dffe463df6f))
 - Make topicName optional on Message::create() ([#7213af9](https://github.com/mateusjunges/laravel-kafka/commit/7213af9b6fc843301d8ffc84e961387d118fde37))
 - Fix `publishOn` and `createConsumer` method signatures on kafka facade ([#eb66e8e](https://github.com/mateusjunges/laravel-kafka/commit/eb66e8efa1a94be020193017dd9ea2f1025c41e9))
-
+- Make message argument optional for `assertPublished` and `assertPublishedOn` methods ([#9ec5eea](https://github.com/mateusjunges/laravel-kafka/commit/9ec5eeabc3bf816211d25bde44354999aa6410df))
 
 ## [2021-11-08 v1.2.0](https://github.com/mateusjunges/laravel-kafka/compare/v1.1.3...v1.2.0)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All relevant changes to `mateusjunges/laravel-kafka` will be documented here.
 
 ## [2021-11-05 v1.1.3](https://github.com/mateusjunges/laravel-kafka/compare/v1.1.2...v1.1.3)
 ### Added
-- Allow usage of custom options for producer config ([[#38ca04](https://github.com/mateusjunges/laravel-kafka/commit/38ca04c15b1feea10c33e9865377f712a1809d40)]) 
+- Allow usage of custom options for producer config ([#38ca04](https://github.com/mateusjunges/laravel-kafka/commit/38ca04c15b1feea10c33e9865377f712a1809d40)) 
 
 ## [2021-10-20 v1.1.2](https://github.com/mateusjunges/laravel-kafka/compare/v1.1.1...v1.1.2)
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Follow these docs to install this package and start using kafka with ease.
   - [4.11 Setting kafka consumer configuration options](#setting-kafka-configuration-options)
   - [4.12 Building the consumer](#building-the-consumer)
   - [4.13 Consuming the kafka message](#consuming-the-kafka-messages)
-- [5. Using custom encoders and decoders]()
+- [5. Using custom encoders and decoders](#using-custom-encodersdecoders)
 - [6. Using `Kafka::fake()`method](#using-kafkafake)
   - [6.1 `assertPublished` method](#assertpublished-method)
   - [6.2 `assertPublishedOn` method](#assertpublishedon-method)
@@ -72,7 +72,15 @@ To publish your messages to Kafka, you can use the `publishOn` method, of `Junge
 ```php
 use Junges\Kafka\Facades\Kafka;
 
-Kafka::publishOn('broker', 'topic');
+Kafka::publishOn('topic');
+```
+
+You can also specify the broker where you want to publish the message:
+
+```php
+use Junges\Kafka\Facades\Kafka;
+
+Kafka::publishOn('topic', 'broker');
 ```
 
 This method returns a `Junges\Kafka\Producers\ProducerBuilder::class` instance, and you can configure your message.
@@ -87,7 +95,7 @@ as argument. Here's an example:
 ```php
 use Junges\Kafka\Facades\Kafka;
 
-Kafka::publishOn('broker', 'topic')
+Kafka::publishOn('topic')
     ->withConfigOption('property-name', 'property-value')
     ->withConfigOptions([
         'property-name' => 'property-value'
@@ -100,7 +108,7 @@ To disable debug mode, you can use `->withDebugEnabled(false)`, or `withDebugDis
 ```php
 use Junges\Kafka\Facades\Kafka;
 
-Kafka::publishOn('broker', 'topic')
+Kafka::publishOn('topic')
     ->withConfigOption('property-name', 'property-value')
     ->withConfigOptions([
         'property-name' => 'property-value'
@@ -113,7 +121,7 @@ Kafka::publishOn('broker', 'topic')
 ### Using custom serializers
 To use custom serializers, you must use the `usingSerializer` method:
 ```php
-$producer = \Junges\Kafka\Facades\Kafka::publishOn('broker', 'topic')->usingSerializer(new MyCustomSerializer());
+$producer = \Junges\Kafka\Facades\Kafka::publishOn('topic')->usingSerializer(new MyCustomSerializer());
 ```
 
 ### Using AVRO serializer
@@ -152,7 +160,7 @@ $registry->addKeySchemaMappingForTopic(
 
 $serializer = new \Junges\Kafka\Message\Serializers\AvroSerializer($registry, $recordSerializer /*, AvroEncoderInterface::ENCODE_BODY */);
 
-$producer = \Junges\Kafka\Facades\Kafka::publishOn('broker', 'topic')->usingSerializer($serializer);
+$producer = \Junges\Kafka\Facades\Kafka::publishOn('topic')->usingSerializer($serializer);
 ```
 
 ### Configuring the Kafka message payload
@@ -165,7 +173,7 @@ To configure the message headers, use the `withHeaders` method:
 ```php
 use Junges\Kafka\Facades\Kafka;
 
-Kafka::publishOn('broker', 'topic')
+Kafka::publishOn('topic')
     ->withHeaders([
         'header-key' => 'header-value'
     ])
@@ -188,7 +196,7 @@ $message = new Message(
     key: 'kafka key here'  
 )
 
-Kafka::publishOn('broker', 'topic')->withMessage($message);
+Kafka::publishOn('topic')->withMessage($message);
 ```
 
 The `withBodyKey` method sets only a key in your message.
@@ -196,7 +204,7 @@ The `withBodyKey` method sets only a key in your message.
 ```php
 use Junges\Kafka\Facades\Kafka;
 
-Kafka::publishOn('broker', 'topic')->withBodyKey('key', 'value');
+Kafka::publishOn('topic')->withBodyKey('key', 'value');
 ```
 
 ### Using Kafka Keys
@@ -206,7 +214,7 @@ If you want to use a key in your message, you should use the `withKafkaKey` meth
 ```php
 use Junges\Kafka\Facades\Kafka;
 
-Kafka::publishOn('broker', 'topic')->withKafkaKey('your-kafka-key');
+Kafka::publishOn('topic')->withKafkaKey('your-kafka-key');
 ```
 
 ## Sending the message to Kafka
@@ -216,7 +224,7 @@ After configuring all your message options, you must use the `send` method, to s
 use Junges\Kafka\Facades\Kafka;
 
 /** @var \Junges\Kafka\Producers\ProducerBuilder $producer */
-$producer = Kafka::publishOn('broker', 'topic')
+$producer = Kafka::publishOn('topic')
     ->withConfigOptions(['key' => 'value'])
     ->withKafkaKey('your-kafka-key')
     ->withKafkaKey('kafka-key')
@@ -233,8 +241,17 @@ To create a consumer using this package, you can use the `createConsumer` method
 ```php
 use Junges\Kafka\Facades\Kafka;
 
-$consumer = Kafka::createConsumer('broker');
+$consumer = Kafka::createConsumer();
 ```
+
+This method also allows you to specify the `topics` it should consume, the `broker` and the consumer `group id`:
+
+```php
+use Junges\Kafka\Facades\Kafka;
+
+$consumer = Kafka::createConsumer(['topic-1', 'topic-2'], 'group-id', 'broker');
+```
+
 
 This method returns a `Junges\Kafka\Consumers\ConsumerBuilder::class` instance, and you can use it to configure your consumer.
 
@@ -244,7 +261,7 @@ With a consumer created, you can subscribe to a kafka topic using the `subscribe
 ```php
 use Junges\Kafka\Facades\Kafka;
 
-$consumer = Kafka::createConsumer('broker')->subscribe('topic');
+$consumer = Kafka::createConsumer()->subscribe('topic');
 ```
 
 Of course, you can subscribe to more than one topic at once, either using an array of topics or specifying one by one:
@@ -252,10 +269,10 @@ Of course, you can subscribe to more than one topic at once, either using an arr
 ```php
 use Junges\Kafka\Facades\Kafka;
 
-$consumer = Kafka::createConsumer('broker')->subscribe('topic-1', 'topic-2', 'topic-n');
+$consumer = Kafka::createConsumer()->subscribe('topic-1', 'topic-2', 'topic-n');
 
 // Or, using array:
-$consumer = Kafka::createConsumer('broker')->subscribe([
+$consumer = Kafka::createConsumer()->subscribe([
     'topic-1',
     'topic-2',
     'topic-n'
@@ -271,7 +288,7 @@ To attach your consumer to a consumer group, you can use the method `withConsume
 ```php
 use Junges\Kafka\Facades\Kafka;
 
-$consumer = Kafka::createConsumer('broker')->withConsumerGroupId('foo');
+$consumer = Kafka::createConsumer()->withConsumerGroupId('foo');
 ```
 
 ## Configuring message handlers
@@ -280,7 +297,7 @@ Now that you have created your kafka consumer, you must create a handler for the
 You can use an invokable class or a simple callback. Use the `withHandler` method to specify your handler:
 
 ```php
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker');
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer();
 
 // Using callback:
 $consumer->withHandler(function(\Junges\Kafka\Contracts\KafkaConsumerMessage $message) {
@@ -298,7 +315,7 @@ class Handler
     }
 }
 
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')->withHandler(Handler::class)
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->withHandler(Handler::class)
 ```
 
 The `KafkaConsumerMessage` contract gives you some handy methods to get the message properties: 
@@ -315,7 +332,7 @@ If you want to consume a limited amount of messages, you can use the `withMaxMes
 kafka consumer:
 
 ```php
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')->withMaxMessages(2);
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->withMaxMessages(2);
 ```
 
 ## Configuring a dead letter queue
@@ -326,10 +343,10 @@ To create a `dlq` in this package, you can use the `withDlq` method. If you don'
 adding the `-dlq` suffix to the topic name.
 
 ```php
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')->withDlq();
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->withDlq();
 
 //Or, specifying the dlq topic name:
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')->withDlq('your-dlq-topic-name')
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->withDlq('your-dlq-topic-name')
 ```
 
 ## Using SASL
@@ -338,7 +355,7 @@ It's also a secure way to enable your clients to endorse an identity. To provide
 passing a `Junges\Kafka\Config\Sasl` instance as the argument:
 
 ```php
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()
     ->withSasl(new \Junges\Kafka\Config\Sasl(
         password: 'password',
         username: 'username'
@@ -349,7 +366,7 @@ $consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')
 You can also set the security protocol used with sasl. It's optional and by default `SASL_PLAINTEXT` is used, but you can set it to `SASL_SSL`:
 
 ```php
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()
     ->withSasl(new \Junges\Kafka\Config\Sasl(
         password: 'password',
         username: 'username'
@@ -364,7 +381,7 @@ use the `withMiddleware` method. The middleware is a callable in which the first
 the next handler. The middlewares get executed in the order they are defined,
 
 ```php
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()
     ->withMiddleware(function($message, callable $next) {
         // Perform some work here
         return $next($message);
@@ -375,7 +392,7 @@ $consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')
 To set the deserializer you want to use, use the `usingDeserializer` method:
 
 ```php
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')->usingDeserializer(new MyCustomDeserializer());
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->usingDeserializer(new MyCustomDeserializer());
 ```
 
 >NOTE: The deserializer class must use the same algorithm as the serializer used to produce this message.
@@ -418,7 +435,7 @@ $registry->addKeySchemaMappingForTopic(
 // per default both key and body will get decoded
 $deserializer = new \Junges\Kafka\Message\Deserializers\AvroDeserializer($registry, $recordSerializer /*, AvroDecoderInterface::DECODE_BODY */);
 
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')->usingDeserializer($deserializer);
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->usingDeserializer($deserializer);
 ```
 
 ## Using auto commit
@@ -426,7 +443,7 @@ The auto-commit check is called in every poll and it checks that the time elapse
 use the `withAutoCommit` method:
 
 ```php
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')->withAutoCommit();
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->withAutoCommit();
 ```
 
 ## Setting Kafka configuration options
@@ -434,12 +451,12 @@ To set configuration options, you can use two methods: `withOptions`, passing an
 passing two arguments, the option name and the option value.
 
 ```php
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()
     ->withOptions([
         'option-name' => 'option-value'
     ]);
 // Or:
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()
     ->withOption('option-name', 'option-value');
 ```
 
@@ -447,7 +464,7 @@ $consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')
 When you have finished configuring your consumer, you must call the `build` method, which returns a `Junges\Kafka\Consumers\Consumer` instance.
 
 ```php
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()
     // Configure your consumer here
     ->build();
 ```
@@ -500,9 +517,9 @@ To set the producer serializer, you must use the `usingSerializer` method, avail
 To set the consumer deserializer, you must use the `usingDeserializer` method, available on the `ConsumerBuilder` class.
 
 ```php
-$producer = \Junges\Kafka\Facades\Kafka::publishOn('broker', 'topic')->usingSerializer(new MyCustomSerializer());
+$producer = \Junges\Kafka\Facades\Kafka::publishOn('topic')->usingSerializer(new MyCustomSerializer());
 
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer('broker')->usingDeserializer(new MyCustomDeserializer());
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->usingDeserializer(new MyCustomDeserializer());
 ```
 
 # Using `Kafka::fake()`
@@ -523,7 +540,7 @@ class MyTest extends TestCase
      {
          Kafka::fake();
          
-         $producer = Kafka::publishOn('broker', 'topic')
+         $producer = Kafka::publishOn('topic')
              ->withHeaders(['key' => 'value'])
              ->withBodyKey('foo', 'bar');
              
@@ -547,7 +564,7 @@ class MyTest extends TestCase
     {
         Kafka::fake();
         
-        $producer = Kafka::publishOn('broker', 'some-kafka-topic')
+        $producer = Kafka::publishOn('some-kafka-topic')
             ->withHeaders(['key' => 'value'])
             ->withBodyKey('key', 'value');
             
@@ -572,7 +589,7 @@ class MyTest extends TestCase
     {
         Kafka::fake();
         
-        $producer = Kafka::publishOn('broker', 'some-kafka-topic')
+        $producer = Kafka::publishOn('some-kafka-topic')
             ->withHeaders(['key' => 'value'])
             ->withBodyKey('key', 'value');
             
@@ -599,7 +616,7 @@ class MyTest extends TestCase
         Kafka::fake();
         
         if (false) {
-            $producer = Kafka::publishOn('broker', 'some-kafka-topic')
+            $producer = Kafka::publishOn('some-kafka-topic')
                 ->withHeaders(['key' => 'value'])
                 ->withBodyKey('key', 'value');
                 

--- a/src/AbstractMessage.php
+++ b/src/AbstractMessage.php
@@ -7,7 +7,7 @@ use Junges\Kafka\Contracts\KafkaMessage;
 abstract class AbstractMessage implements KafkaMessage
 {
     public function __construct(
-        protected string  $topicName,
+        protected ?string  $topicName = null,
         protected ?int    $partition = RD_KAFKA_PARTITION_UA,
         protected ?array  $headers = [],
         protected mixed   $body = [],
@@ -15,7 +15,14 @@ abstract class AbstractMessage implements KafkaMessage
     ) {
     }
 
-    public function getTopicName(): string
+    public function setTopicName(string $topic): self
+    {
+        $this->topicName = $topic;
+
+        return $this;
+    }
+
+    public function getTopicName(): ?string
     {
         return $this->topicName;
     }

--- a/src/Contracts/CanProduceMessages.php
+++ b/src/Contracts/CanProduceMessages.php
@@ -7,7 +7,7 @@ use Junges\Kafka\Message\Message;
 
 interface CanProduceMessages
 {
-    public static function create(string $broker, string $topic): self;
+    public static function create(string $topic, string $broker = null): self;
 
     public function withConfigOption(string $name, string $option): self;
 

--- a/src/Contracts/CanPublishMessagesToKafka.php
+++ b/src/Contracts/CanPublishMessagesToKafka.php
@@ -4,5 +4,5 @@ namespace Junges\Kafka\Contracts;
 
 interface CanPublishMessagesToKafka
 {
-    public function publishOn(string $broker, string $topic): CanProduceMessages;
+    public function publishOn(string $topic, string $broker = null): CanProduceMessages;
 }

--- a/src/Contracts/KafkaMessage.php
+++ b/src/Contracts/KafkaMessage.php
@@ -6,7 +6,7 @@ interface KafkaMessage
 {
     public function getKey(): mixed;
 
-    public function getTopicName(): string;
+    public function getTopicName(): ?string;
 
     public function getPartition(): ?int;
 

--- a/src/Facades/Kafka.php
+++ b/src/Facades/Kafka.php
@@ -7,12 +7,14 @@ use Junges\Kafka\Message\Message;
 use Junges\Kafka\Support\Testing\Fakes\KafkaFake;
 
 /**
- * @method static \Junges\Kafka\Contracts\CanProduceMessages publishOn(string $broker, string $topic);
- * @method static \Junges\Kafka\Consumers\ConsumerBuilder createConsumer(string $brokers, array $topics = [], string $groupId = null);
+ * @method static \Junges\Kafka\Contracts\CanProduceMessages publishOn(string $topic, string $broker = null);
+ * @method static \Junges\Kafka\Consumers\ConsumerBuilder createConsumer(array $topics = [], string $groupId = null, string $brokers = null);
  * @method static void assertPublished(Message $message);
  * @method static void assertPublishedOn(string $topic, Message $message, $callback = null)
  * @method static void assertNothingPublished()
  * @mixin \Junges\Kafka\Kafka
+ *
+ * @see \Junges\Kafka\Kafka
  */
 class Kafka extends Facade
 {

--- a/src/Kafka.php
+++ b/src/Kafka.php
@@ -12,30 +12,30 @@ class Kafka implements CanPublishMessagesToKafka
     /**
      * Creates a new ProducerBuilder instance, setting brokers and topic.
      *
-     * @param string $broker
+     * @param string|null $broker
      * @param string $topic
      * @return CanProduceMessages
      */
-    public function publishOn(string $broker, string $topic): CanProduceMessages
+    public function publishOn(string $topic, string $broker = null): CanProduceMessages
     {
         return new ProducerBuilder(
-            broker: $broker,
-            topic: $topic
+            topic: $topic,
+            broker: $broker ?? config('kafka.brokers')
         );
     }
 
     /**
      * Return a ConsumerBuilder instance.
      *
-     * @param string $brokers
      * @param array $topics
      * @param string|null $groupId
+     * @param string|null $brokers
      * @return \Junges\Kafka\Consumers\ConsumerBuilder
      */
-    public function createConsumer(string $brokers, array $topics = [], string $groupId = null): ConsumerBuilder
+    public function createConsumer(array $topics = [], string $groupId = null, string $brokers = null): ConsumerBuilder
     {
         return ConsumerBuilder::create(
-            brokers: $brokers,
+            brokers: $brokers ?? config('kafka.brokers'),
             topics: $topics,
             groupId: $groupId
         );

--- a/src/Message/ConsumedMessage.php
+++ b/src/Message/ConsumedMessage.php
@@ -8,7 +8,7 @@ use Junges\Kafka\Contracts\KafkaConsumerMessage;
 class ConsumedMessage extends AbstractMessage implements KafkaConsumerMessage
 {
     public function __construct(
-        protected string $topicName,
+        protected ?string $topicName,
         protected ?int $partition,
         protected ?array $headers,
         protected mixed $body,

--- a/src/Message/Message.php
+++ b/src/Message/Message.php
@@ -4,20 +4,21 @@ namespace Junges\Kafka\Message;
 
 use Illuminate\Contracts\Support\Arrayable;
 use JetBrains\PhpStorm\ArrayShape;
+use JetBrains\PhpStorm\Pure;
 use Junges\Kafka\AbstractMessage;
 use Junges\Kafka\Contracts\KafkaProducerMessage;
-use const RD_KAFKA_PARTITION_UA;
 
 class Message extends AbstractMessage implements Arrayable, KafkaProducerMessage
 {
     /**
      * Creates a new message instance.
      *
-     * @param string $topicName
+     * @param string|null $topicName
      * @param int $partition
      * @return Message
      */
-    public static function create(string $topicName, int $partition = RD_KAFKA_PARTITION_UA): KafkaProducerMessage
+    #[Pure]
+    public static function create(string $topicName = null, int $partition = RD_KAFKA_PARTITION_UA): KafkaProducerMessage
     {
         return new self($topicName, $partition);
     }

--- a/src/Producers/Producer.php
+++ b/src/Producers/Producer.php
@@ -5,7 +5,6 @@ namespace Junges\Kafka\Producers;
 use Junges\Kafka\Config\Config;
 use Junges\Kafka\Contracts\KafkaProducerMessage;
 use Junges\Kafka\Contracts\MessageSerializer;
-use Junges\Kafka\Message\Message;
 use Mockery\Exception;
 use RdKafka\Conf;
 use RdKafka\Producer as KafkaProducer;

--- a/src/Producers/ProducerBuilder.php
+++ b/src/Producers/ProducerBuilder.php
@@ -2,7 +2,6 @@
 
 namespace Junges\Kafka\Producers;
 
-use JetBrains\PhpStorm\Pure;
 use Junges\Kafka\Config\Config;
 use Junges\Kafka\Config\Sasl;
 use Junges\Kafka\Contracts\CanProduceMessages;

--- a/src/Producers/ProducerBuilder.php
+++ b/src/Producers/ProducerBuilder.php
@@ -16,29 +16,30 @@ class ProducerBuilder implements CanProduceMessages
     private KafkaProducerMessage $message;
     private MessageSerializer $serializer;
     private ?Sasl $saslConfig = null;
+    private string $broker;
 
     public function __construct(
-        private string $broker,
-        private string $topic
+        private string $topic,
+        ?string $broker = null,
     ) {
         /** @var KafkaProducerMessage $message */
         $message = app(KafkaProducerMessage::class);
         $this->message = $message->create($topic);
         $this->serializer = app(MessageSerializer::class);
+        $this->broker = $broker ?? config('kafka.brokers');
     }
 
     /**
      * Return a new Junges\Commit\ProducerBuilder instance
-     * @param string $broker
      * @param string $topic
+     * @param string|null $broker
      * @return static
      */
-    #[Pure]
-    public static function create(string $broker, string $topic): self
+    public static function create(string $topic, string $broker = null): self
     {
         return new ProducerBuilder(
-            broker: $broker,
-            topic: $topic
+            topic: $topic,
+            broker: $broker ?? config('kafka.brokers')
         );
     }
 

--- a/src/Support/Testing/Fakes/KafkaFake.php
+++ b/src/Support/Testing/Fakes/KafkaFake.php
@@ -14,8 +14,8 @@ class KafkaFake implements CanPublishMessagesToKafka
     public function __construct()
     {
         $this->producerBuilderFake = new ProducerBuilderFake(
-            broker: '',
-            topic: ''
+            topic: '',
+            broker: ''
         );
 
         return $this->producerBuilderFake;
@@ -24,15 +24,15 @@ class KafkaFake implements CanPublishMessagesToKafka
     /**
      * Publish a message in the specified broker/topic.
      *
-     * @param string $broker
      * @param string $topic
+     * @param string|null $broker
      * @return ProducerBuilderFake
      */
-    public function publishOn(string $broker, string $topic): ProducerBuilderFake
+    public function publishOn(string $topic, string $broker = null): ProducerBuilderFake
     {
         $this->producerBuilderFake = new ProducerBuilderFake(
-            broker: $broker,
-            topic: $topic
+            topic: $topic,
+            broker: $broker
         );
 
         return $this->producerBuilderFake;

--- a/src/Support/Testing/Fakes/ProducerBuilderFake.php
+++ b/src/Support/Testing/Fakes/ProducerBuilderFake.php
@@ -18,8 +18,8 @@ class ProducerBuilderFake implements CanProduceMessages
     private ?Sasl $saslConfig = null;
 
     public function __construct(
-        private string $broker,
         private string $topic,
+        private ?string $broker = null,
     ) {
         $this->message = new Message($topic);
 
@@ -37,11 +37,11 @@ class ProducerBuilderFake implements CanProduceMessages
 
     /**
      * Return a new Junges\Commit\ProducerBuilder instance
-     * @param string $broker
      * @param string $topic
+     * @param string|null $broker
      * @return static
      */
-    public static function create(string $broker, string $topic): self
+    public static function create(string $topic, string $broker = null): self
     {
         return new ProducerBuilderFake($broker, $topic);
     }
@@ -171,6 +171,10 @@ class ProducerBuilderFake implements CanProduceMessages
      */
     public function send(): bool
     {
+        if ($this->getMessage()->getTopicName() === null) {
+            $this->message->setTopicName($this->getTopic());
+        }
+
         $producer = $this->build();
 
         return $producer->produce($this->getMessage());
@@ -189,7 +193,7 @@ class ProducerBuilderFake implements CanProduceMessages
     private function build(): ProducerFake
     {
         $conf = new Config(
-            broker: $this->broker,
+            broker: $this->broker ?? config('kafka.brokers'),
             topics: [$this->getTopic()],
             sasl: $this->saslConfig,
             customOptions: $this->options

--- a/tests/Consumers/ConsumerTest.php
+++ b/tests/Consumers/ConsumerTest.php
@@ -60,7 +60,7 @@ class ConsumerTest extends LaravelKafkaTestCase
 
         $this->mockProducer();
 
-        $consumer = Kafka::createConsumer('broker', ['test'])
+        $consumer = Kafka::createConsumer(['test'])
             ->withHandler($fakeConsumer = new FakeConsumer())
             ->withAutoCommit()
             ->withMaxMessages(1)

--- a/tests/KafkaFakeTest.php
+++ b/tests/KafkaFakeTest.php
@@ -57,7 +57,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
 
     public function testItCanPerformAssertionsOnPublishedMessages()
     {
-        $producer = $this->fake->publishOn( 'topic')
+        $producer = $this->fake->publishOn('topic')
             ->withBodyKey('test', ['test'])
             ->withHeaders(['custom' => 'header'])
             ->withKafkaKey($uuid = Str::uuid()->toString());

--- a/tests/KafkaFakeTest.php
+++ b/tests/KafkaFakeTest.php
@@ -28,7 +28,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
 
     public function testItStorePublishedMessagesOnArray()
     {
-        $producer = $this->fake->publishOn('broker', 'test_topic_1')
+        $producer = $this->fake->publishOn('topic')
             ->withBodyKey('test', ['test'])
             ->withHeaders(['custom' => 'header'])
             ->withKafkaKey(Str::uuid()->toString());
@@ -46,7 +46,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
             $this->assertThat($exception, new ExceptionMessage('The expected message was not published.'));
         }
 
-        $producer = $this->fake->publishOn('broker', 'topic')
+        $producer = $this->fake->publishOn('topic')
             ->withBodyKey('test', ['test'])
             ->withHeaders(['custom' => 'header'])
             ->withKafkaKey(Str::uuid()->toString());
@@ -57,7 +57,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
 
     public function testItCanPerformAssertionsOnPublishedMessages()
     {
-        $producer = $this->fake->publishOn('broker', 'topic')
+        $producer = $this->fake->publishOn( 'topic')
             ->withBodyKey('test', ['test'])
             ->withHeaders(['custom' => 'header'])
             ->withKafkaKey($uuid = Str::uuid()->toString());
@@ -86,7 +86,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
 
     public function testAssertPublishedOn()
     {
-        $producer = $this->fake->publishOn('broker', 'topic')
+        $producer = $this->fake->publishOn('topic')
             ->withBodyKey('test', ['test'])
             ->withHeaders(['custom' => 'header'])
             ->withKafkaKey(Str::uuid()->toString());
@@ -106,7 +106,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
 
     public function testICanPerformAssertionsUsingAssertPublishedOn()
     {
-        $producer = $this->fake->publishOn('broker', 'topic')
+        $producer = $this->fake->publishOn('topic')
             ->withBodyKey('test', ['test'])
             ->withHeaders(['custom' => 'header'])
             ->withKafkaKey($uuid = Str::uuid()->toString());

--- a/tests/KafkaTest.php
+++ b/tests/KafkaTest.php
@@ -31,7 +31,7 @@ class KafkaTest extends LaravelKafkaTestCase
             return $mockedProducer;
         });
 
-        $test = Kafka::publishOn('localhost:9092', 'test-topic')
+        $test = Kafka::publishOn('test-topic')
             ->withConfigOptions([
                 'metadata.broker.list' => 'broker',
             ])
@@ -61,7 +61,7 @@ class KafkaTest extends LaravelKafkaTestCase
             return $mockedProducer;
         });
 
-        $producer = Kafka::publishOn('localhost:9092', 'test-topic')
+        $producer = Kafka::publishOn('test-topic')
             ->withConfigOptions([
                 'metadata.broker.list' => 'broker',
             ])
@@ -96,7 +96,7 @@ class KafkaTest extends LaravelKafkaTestCase
 
         Kafka::fake();
 
-        $test = Kafka::publishOn('localhost:9092', 'test-topic')
+        $test = Kafka::publishOn('test-topic')
             ->withConfigOptions([
                 'metadata.broker.list' => 'broker',
             ])
@@ -126,9 +126,9 @@ class KafkaTest extends LaravelKafkaTestCase
             return $mockedProducer;
         });
 
-        $message = Message::create('foo')->withHeaders(['foo' => 'bar'])->withKey('message-key')->withBody(['foo' => 'bar']);
+        $message = Message::create()->withHeaders(['foo' => 'bar'])->withKey('message-key')->withBody(['foo' => 'bar']);
 
-        $test = Kafka::publishOn('localhost:9092', 'test-topic')
+        $test = Kafka::publishOn('test-topic')
             ->withConfigOptions([
                 'metadata.broker.list' => 'broker',
             ])
@@ -138,12 +138,11 @@ class KafkaTest extends LaravelKafkaTestCase
 
         $this->assertTrue($test);
 
-        $test = Kafka::publishOn('localhost:9092', 'test-topic')
+        $test = Kafka::publishOn('test-topic')
             ->withConfigOptions([
                 'metadata.broker.list' => 'broker',
             ])
             ->withMessage(new Message(
-                topicName: 'foo',
                 headers: ['foo' => 'bar'],
                 body: ['foo' => 'bar'],
                 key: 'message-key'
@@ -172,7 +171,7 @@ class KafkaTest extends LaravelKafkaTestCase
         });
 
         /** @var ProducerBuilder $producer */
-        $producer = Kafka::publishOn('localhost:9092', 'test-topic')
+        $producer = Kafka::publishOn('test-topic')
             ->withConfigOptions([
                 'metadata.broker.list' => 'broker',
             ])
@@ -195,7 +194,7 @@ class KafkaTest extends LaravelKafkaTestCase
 
     public function testICanUseCustomOptionsForProducerConfig()
     {
-        $producer = Kafka::publishOn('localhost:9092', 'test-topic')
+        $producer = Kafka::publishOn('test-topic')
             ->withConfigOptions($expectedOptions = [
                 'bootstrap.servers' => '[REMOTE_ADDRESS]',
                 'metadata.broker.list' => '[REMOTE_ADDRESS]',
@@ -212,7 +211,7 @@ class KafkaTest extends LaravelKafkaTestCase
 
     public function testCreateConsumerReturnsAConsumerBuilderInstance()
     {
-        $consumer = Kafka::createConsumer('broker');
+        $consumer = Kafka::createConsumer();
 
         $this->assertInstanceOf(ConsumerBuilder::class, $consumer);
     }

--- a/tests/LaravelKafkaTestCase.php
+++ b/tests/LaravelKafkaTestCase.php
@@ -23,6 +23,18 @@ class LaravelKafkaTestCase extends Orchestra
         app()->instance(Logger::class, $this->getMockedLogger());
     }
 
+    public function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('kafka.brokers', 'localhost:9092');
+        $app['config']->set('kafka.consumer_group_id', 'group');
+        $app['config']->set('kafka.offset_reset', 'latest');
+        $app['config']->set('kafka.auto_commit', true);
+        $app['config']->set('kafka.sleep_on_error', 5);
+        $app['config']->set('kafka.partition', 0);
+        $app['config']->set('kafka.compression', 'snappy');
+        $app['config']->set('kafka.debug', false);
+    }
+
     protected function getPackageProviders($app): array
     {
         return [

--- a/tests/Message/MessageTest.php
+++ b/tests/Message/MessageTest.php
@@ -13,7 +13,7 @@ class MessageTest extends LaravelKafkaTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->message = new Message('foo');
+        $this->message = new Message();
     }
 
     public function testItCanSetAMessageKey()
@@ -21,7 +21,6 @@ class MessageTest extends LaravelKafkaTestCase
         $this->message->withBodyKey('foo', 'bar');
 
         $expected = new Message(
-            topicName: 'foo',
             body: ['foo' => 'bar']
         );
 
@@ -34,7 +33,6 @@ class MessageTest extends LaravelKafkaTestCase
         $this->message->withBodyKey('bar', 'foo');
 
         $expected = new Message(
-            topicName: 'foo',
             body: ['bar' => 'foo']
         );
 
@@ -50,7 +48,6 @@ class MessageTest extends LaravelKafkaTestCase
         ]);
 
         $expected = new Message(
-            topicName: 'foo',
             headers: ['foo' => 'bar']
         );
 
@@ -62,7 +59,6 @@ class MessageTest extends LaravelKafkaTestCase
         $this->message->withKey($uuid = Str::uuid()->toString());
 
         $expected = new Message(
-            topicName: 'foo',
             key: $uuid
         );
 
@@ -75,7 +71,6 @@ class MessageTest extends LaravelKafkaTestCase
         $this->message->withBodyKey('bar', 'foo');
 
         $expectedMessage = new Message(
-            topicName: 'foo',
             body: $array = ['foo' => 'bar', 'bar' => 'foo']
         );
 
@@ -94,7 +89,6 @@ class MessageTest extends LaravelKafkaTestCase
         $this->message->withHeaders($headers = ['foo' => 'bar']);
 
         $expectedMessage = new Message(
-            topicName: 'foo',
             headers: $headers,
             body: $array = ['foo' => 'bar', 'bar' => 'foo'],
             key: $uuid


### PR DESCRIPTION
This PR makes the `broker` parameter optional on `publishOn` and `createConsumer` methods. If not informed, the default from `config(kafka.brokers)` will be used. The `topic` parameter on message constructor isn't required anymore, since it is used for tests only. The topic name is set in runtime if using kafka fake driver.

### Added
- Added `assertPublishedTimes` and `assertPublishedOnTimes` methods ([#a16a10d](https://github.com/mateusjunges/laravel-kafka/commit/a16a10dbe9ddfbbe5e412148b2083faead774cf8))

### Changed
- Make topic name optional. Add method to set topic name when using fake driver ([#12dde5](https://github.com/mateusjunges/laravel-kafka/commit/12dde5de2aa8b9d735fa3fb093dc48948733f3a3), [#8f5b25](https://github.com/mateusjunges/laravel-kafka/commit/8f5b258609cbd6f475aee4e9a9517daeffcd5b60), [#f3c8b43](https://github.com/mateusjunges/laravel-kafka/commit/f3c8b4392872063060891bc9f2152712b639e81b), [#fe19922](https://github.com/mateusjunges/laravel-kafka/commit/fe199227fd1b657660d30fb7fc0cca41d5a4d24f))
- Make broker parameter optional ([#5625bef](https://github.com/mateusjunges/laravel-kafka/commit/5625befca0c11ae19b109f1368d42d5aaa284da2), [#aa5596c](https://github.com/mateusjunges/laravel-kafka/commit/aa5596c21910bae780e9f4be8afb5864a6b8eab7), [#c6ad0e9](https://github.com/mateusjunges/laravel-kafka/commit/c6ad0e98ee65536d30a09bdaeb89c3e184860f07), [#5117cd8](https://github.com/mateusjunges/laravel-kafka/commit/5117cd8eeb435ab1774144cca1ef6ed36b0d09d7))
- Allow getTopicName to return null on KafkaMessage contract ([#3e6289d](https://github.com/mateusjunges/laravel-kafka/commit/3e6289d91cf36bdc185eb142810b1dffe463df6f))
- Make topicName optional on Message::create() ([#7213af9](https://github.com/mateusjunges/laravel-kafka/commit/7213af9b6fc843301d8ffc84e961387d118fde37))
- Fix `publishOn` and `createConsumer` method signatures on kafka facade ([#eb66e8e](https://github.com/mateusjunges/laravel-kafka/commit/eb66e8efa1a94be020193017dd9ea2f1025c41e9))
- Make message argument optional for `assertPublished` and `assertPublishedOn` methods ([#9ec5eea](https://github.com/mateusjunges/laravel-kafka/commit/9ec5eeabc3bf816211d25bde44354999aa6410df))



