### PR TITLE
Thetomcake/fix incorrect message published count

### DIFF
--- a/src/Support/Testing/Fakes/KafkaFake.php
+++ b/src/Support/Testing/Fakes/KafkaFake.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use JetBrains\PhpStorm\Pure;
 use Junges\Kafka\Contracts\CanPublishMessagesToKafka;
 use Junges\Kafka\Contracts\KafkaProducerMessage;
+use Junges\Kafka\Message\Message;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class KafkaFake implements CanPublishMessagesToKafka
@@ -42,13 +43,13 @@ class KafkaFake implements CanPublishMessagesToKafka
     /**
      * Assert if a messages was published based on a truth-test callback.
      *
-     * @param KafkaProducerMessage|null $message
+     * @param KafkaProducerMessage|null $expectedMessage
      * @param null $callback
      */
-    public function assertPublished(KafkaProducerMessage $message = null, $callback = null)
+    public function assertPublished(?KafkaProducerMessage $expectedMessage = null, ?callable $callback = null)
     {
         PHPUnit::assertTrue(
-            condition: $this->published($message, $callback)->count() > 0,
+            condition: $this->published(null, $expectedMessage, $callback)->count() > 0,
             message: "The expected message was not published."
         );
     }
@@ -56,12 +57,12 @@ class KafkaFake implements CanPublishMessagesToKafka
     /**
      * Assert if a messages was published based on a truth-test callback.
      *
-     * @param KafkaProducerMessage|null $message
-     * @param null $callback
+     * @param KafkaProducerMessage|null $expectedMessage
+     * @param callable|null $callback
      */
-    public function assertPublishedTimes(int $times = 1, KafkaProducerMessage $message = null, $callback = null)
+    public function assertPublishedTimes(int $times = 1, ?KafkaProducerMessage $expectedMessage = null, ?callable $callback = null)
     {
-        $count = $this->published($message, $callback)->count();
+        $count = $this->published(null, $expectedMessage, $callback)->count();
 
         PHPUnit::assertTrue(
             condition: $count === $times,
@@ -73,28 +74,15 @@ class KafkaFake implements CanPublishMessagesToKafka
      * Assert that a message was published on a specific topic.
      *
      * @param string $topic
-     * @param KafkaProducerMessage|null $message
+     * @param KafkaProducerMessage|null $expectedMessage
      * @param callable|null $callback
      */
-    public function assertPublishedOn(string $topic, KafkaProducerMessage $message = null, callable $callback = null)
+    public function assertPublishedOn(string $topic, ?KafkaProducerMessage $expectedMessage = null, ?callable $callback = null)
     {
-        if ($message === null) {
-            $this->assertPublished(null, function ($messageArray, $publishedTopic) use ($topic) {
-                return $topic === $publishedTopic;
-            });
-
-            return;
-        }
-
-        $this->assertPublished($message, function ($messageArray, $publishedTopic) use ($callback, $topic, $message) {
-            if ($publishedTopic !== $topic) {
-                return false;
-            }
-
-            return $callback
-                ? $callback($message, $messageArray)
-                : true;
-        });
+        PHPUnit::assertTrue(
+            condition: $this->published($topic, $expectedMessage, $callback)->count() > 0,
+            message: "The expected message was not published."
+        );
     }
 
     /**
@@ -102,20 +90,17 @@ class KafkaFake implements CanPublishMessagesToKafka
      *
      * @param string $topic
      * @param int $times
-     * @param KafkaProducerMessage|null $message
+     * @param KafkaProducerMessage|null $expectedMessage
      * @param callable|null $callback
      */
-    public function assertPublishedOnTimes(string $topic, int $times = 1, KafkaProducerMessage $message = null, callable $callback = null)
+    public function assertPublishedOnTimes(string $topic, int $times = 1, ?KafkaProducerMessage $expectedMessage = null, ?callable $callback = null)
     {
-        $this->assertPublishedTimes($times, $message, function ($messageArray, $publishedTopic) use ($callback, $topic, $message) {
-            if ($publishedTopic !== $topic) {
-                return false;
-            }
+        $count = $this->published($topic, $expectedMessage, $callback)->count();
 
-            return $callback
-                ? $callback($message, $messageArray)
-                : true;
-        });
+        PHPUnit::assertTrue(
+            condition: $count === $times,
+            message: "Kafka published {$count} messages instead of {$times}."
+        );
     }
 
     /**
@@ -129,23 +114,28 @@ class KafkaFake implements CanPublishMessagesToKafka
     /**
      * Get all messages matching a truth-test callback.
      *
-     * @param KafkaProducerMessage|null $message
+     * @param string|null $topic
+     * @param KafkaProducerMessage|null $expectedMessage
      * @param null $callback
      * @return \Illuminate\Support\Collection
      */
-    private function published(KafkaProducerMessage $message = null, $callback = null): Collection
+    private function published(?string $topic, ?KafkaProducerMessage $expectedMessage = null, ?callable $callback = null): Collection
     {
         if (! $this->hasPublished()) {
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        return collect($this->getPublishedMessages())->filter(function (Message $publishedMessage) use ($topic, $expectedMessage, $callback) {
+            if ($topic !== null && $publishedMessage->getTopicName() !== $topic) {
+                return false;
+            }
+            if ($callback !== null) {
+                $callback($publishedMessage);
+            }
+            if ($expectedMessage !== null) {
+                return json_encode($publishedMessage->toArray()) === json_encode($expectedMessage->toArray());
+            }
             return true;
-        };
-
-
-        return collect($this->getPublishedMessages())->filter(function ($_, $topic) use ($message, $callback) {
-            return $callback($message, $topic);
         });
     }
 

--- a/src/Support/Testing/Fakes/ProducerFake.php
+++ b/src/Support/Testing/Fakes/ProducerFake.php
@@ -23,7 +23,7 @@ class ProducerFake
 
     public function produce(Message $message): bool
     {
-        $this->messages[$this->topic][] = json_encode($message->toArray());
+        $this->messages[] = $message;
 
         return true;
     }

--- a/src/Support/Testing/Fakes/ProducerFake.php
+++ b/src/Support/Testing/Fakes/ProducerFake.php
@@ -3,12 +3,14 @@
 namespace Junges\Kafka\Support\Testing\Fakes;
 
 use Junges\Kafka\Config\Config;
+use Junges\Kafka\Facades\Kafka;
 use Junges\Kafka\Message\Message;
 use RdKafka\Conf;
 
 class ProducerFake
 {
     private array $messages = [];
+    private $produceCallback = null;
 
     public function __construct(
         private Config $config,
@@ -21,15 +23,19 @@ class ProducerFake
         return new Conf();
     }
 
-    public function produce(Message $message): bool
+    public function withProduceCallback(callable $callback): self
     {
-        $this->messages[] = $message;
-
-        return true;
+        $this->produceCallback = $callback;
+        return $this;
     }
 
-    public function getPublishedMessages(): array
+    public function produce(Message $message): bool
     {
-        return $this->messages;
+        if ($this->produceCallback !== null) {
+            $callback = $this->produceCallback;
+            $callback($message);
+        }
+
+        return true;
     }
 }

--- a/tests/KafkaFakeTest.php
+++ b/tests/KafkaFakeTest.php
@@ -177,7 +177,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
     {
         $this->fake->assertNothingPublished();
 
-        $this->fake->publishOn('broker', 'topic')->withMessage(new Message('foo'))->send();
+        $this->fake->publishOn('topic', 'broker')->withMessage(new Message('foo'))->send();
 
         try {
             $this->fake->assertNothingPublished();

--- a/tests/KafkaFakeTest.php
+++ b/tests/KafkaFakeTest.php
@@ -72,7 +72,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->fake->assertPublishedTimes(1, $producer->getMessage());
 
         try {
-            $this->fake->assertPublishedTimes(2, new Message('foo'));
+            $this->fake->assertPublishedTimes(2);
         } catch (ExpectationFailedException $exception) {
             $this->assertThat($exception, new ExceptionMessage('Kafka published 1 messages instead of 2.'));
         }


### PR DESCRIPTION
This Pr also includes #22 

------

It addresses the issue mentioned at the bottom of #22 

> One thing i cannot figure out is why the publishedMessages is stored on the `ProducerFake` object. This object is recreated everytime a new message is published.

>This means that if you run the following test always fails because it can only ever be as high as 1.
```php
Kafka::fake();
Kafka::publishOn('topic')->withHeaders(['custom' => 'header'])->send();
Kafka::publishOn('topic')->withHeaders(['custom' => 'header2'])->send();
Kafka::assertPublishedOnTimes('topic', 2)
```

------

I have attempted a fix here, it works, i'm not amazingly happy with it.