### PR TITLE
[1.4.x] Added graceful shutdown function to consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,6 @@ pcntl_signal(SIGINT, fn() => gracefulShutdown($consumer));
 $consumer->consume();
 ```
 
-
 ## Configuring a dead letter queue
 In kafka, a Dead Letter Queue (or DLQ), is a simple kafka topic in the kafka cluster which acts as the destination for messages that were not
 able to make it to the desired destination due to some error.

--- a/README.md
+++ b/README.md
@@ -31,15 +31,16 @@ Follow these docs to install this package and start using kafka with ease.
   - [4.2 Configuring consumer groups](#configuring-consumer-groups)
   - [4.3 Configuring message handlers](#configuring-message-handlers)
   - [4.4 Configuring max messages to be consumed](#configuring-max-messages-to-be-consumed)
-  - [4.5 Configuring a dead letter queue](#configuring-a-dead-letter-queue)
-  - [4.6 Using SASL](#using-sasl)
-  - [4.7 Using middlewares](#using-middlewares)
-  - [4.8 Using custom deserializers](#using-custom-deserializers)
-  - [4.9 Using AVRO deserializer](#using-avro-deserializer)
-  - [4.10 Using auto-commit](#using-auto-commit)
-  - [4.11 Setting kafka consumer configuration options](#setting-kafka-configuration-options)
-  - [4.12 Building the consumer](#building-the-consumer)
-  - [4.13 Consuming the kafka message](#consuming-the-kafka-messages)
+  - [4.5 Stopping consumer](#stopping-consumer-using-pcntl)
+  - [4.6 Configuring a dead letter queue](#configuring-a-dead-letter-queue)
+  - [4.7 Using SASL](#using-sasl)
+  - [4.8 Using middlewares](#using-middlewares)
+  - [4.9 Using custom deserializers](#using-custom-deserializers)
+  - [4.10 Using AVRO deserializer](#using-avro-deserializer)
+  - [4.11 Using auto-commit](#using-auto-commit)
+  - [4.12 Setting kafka consumer configuration options](#setting-kafka-configuration-options)
+  - [4.13 Building the consumer](#building-the-consumer)
+  - [4.14 Consuming the kafka message](#consuming-the-kafka-messages)
 - [5. Using custom encoders and decoders](#using-custom-encodersdecoders)
 - [6. Using `Kafka::fake()`method](#using-kafkafake)
   - [6.1 `assertPublished` method](#assertpublished-method)
@@ -336,6 +337,33 @@ kafka consumer:
 ```php
 $consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->withMaxMessages(2);
 ```
+
+## Stopping consumer using pcntl
+
+Stopping consumers is very useful if you want to ensure you don't kill a process halfway through processing a consumed message.
+
+To stop the consumer gracefully call the `stopConsume` method on a consumer instance.
+
+This is particularly useful when using signal handlers. **NOTE** You will require the [Process Control Extension](https://www.php.net/manual/en/book.pcntl.php) to be installed to utilise the pcntl methods.
+
+```php
+function gracefulShutdown(Consumer $consumer) {
+    $consumer->stopConsume(function() {
+        echo 'Stopped consuming';
+        exit(0);
+    });
+}
+
+$consumer = Kafka::createConsumer(['topic'])
+    ->withConsumerGroupId('group')
+    ->withHandler(Handler::class)
+    ->build();
+    
+pcntl_signal(SIGINT, fn() => gracefulShutdown($consumer));
+
+$consumer->consume();
+```
+
 
 ## Configuring a dead letter queue
 In kafka, a Dead Letter Queue (or DLQ), is a simple kafka topic in the kafka cluster which acts as the destination for messages that were not

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -125,7 +125,7 @@ class Consumer
      */
     private function doConsume()
     {
-        $message = $this->consumer->consume(120000);
+        $message = $this->consumer->consume(2000);
         $this->handleMessage($message);
     }
 

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -18,6 +18,7 @@ use RdKafka\KafkaConsumer;
 use RdKafka\Message;
 use RdKafka\Producer as KafkaProducer;
 use Throwable;
+use Closure;
 
 class Consumer
 {
@@ -44,6 +45,8 @@ class Consumer
     private Retryable $retryable;
     private CommitterFactory $committerFactory;
     private MessageDeserializer $decoder;
+    private bool $stopRequested = false;
+    private ?Closure $onStopConsume = null;
 
     /**
      * @param \Junges\Kafka\Config\Config $config
@@ -65,6 +68,7 @@ class Consumer
      */
     public function consume(): void
     {
+        $this->cancelStopConsume();
         $this->consumer = app(KafkaConsumer::class, [
             'conf' => $this->setConf($this->config->getConsumerOptions()),
         ]);
@@ -78,7 +82,39 @@ class Consumer
 
         do {
             $this->retryable->retry(fn () => $this->doConsume());
-        } while (! $this->maxMessagesLimitReached());
+        } while (! $this->maxMessagesLimitReached() && ! $this->stopRequested);
+
+        if ($this->onStopConsume) {
+            Closure::fromCallable($this->onStopConsume)();
+        }
+    }
+
+    /**
+     * Requests the consumer to stop after it's finished processing any messages to allow graceful exit
+     *
+     * @param Closure|null $onStop
+     */
+    public function stopConsume(?Closure $onStop = null): void
+    {
+        $this->stopRequested = true;
+        $this->onStopConsume = $onStop;
+    }
+
+    /**
+     * Will cancel the stopConsume request initiated by calling the stopConsume method
+     */
+    public function cancelStopConsume(): void
+    {
+        $this->stopRequested = false;
+        $this->onStopConsume = null;
+    }
+
+    /**
+     * Count the number of messages consumed by this consumer
+     */
+    public function consumedMessagesCount(): int
+    {
+        return $this->messageCounter->messagesCounted();
     }
 
     /**

--- a/src/MessageCounter.php
+++ b/src/MessageCounter.php
@@ -17,6 +17,11 @@ class MessageCounter
         return $this;
     }
 
+    public function messagesCounted(): int
+    {
+        return $this->messageCount;
+    }
+
     public function maxMessagesLimitReached(): bool
     {
         return $this->maxMessages === $this->messageCount;

--- a/tests/LaravelKafkaTestCase.php
+++ b/tests/LaravelKafkaTestCase.php
@@ -85,14 +85,16 @@ class LaravelKafkaTestCase extends Orchestra
         });
     }
 
-    protected function mockConsumerWithMessage(Message $message)
+    protected function mockConsumerWithMessage(Message ...$message)
     {
         $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
             ->shouldReceive('subscribe')
             ->andReturn(m::self())
             ->shouldReceive('consume')
             ->withAnyArgs()
-            ->andReturn($message)
+            ->andReturnUsing(function() use (&$message) {
+                return array_splice($message, 0, 1)[0] ?? null;
+            })
             ->shouldReceive('commit')
             ->andReturn()
             ->getMock();


### PR DESCRIPTION
We were looking at adding graceful shutdown to the library as we use it inside k8s and we are currently unable to stop kafka consumers without killing the container.

Hopefully this should help for anyone in a similar situation.