### PR TITLE
Add message context to Committers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Follow these docs to install this package and start using kafka with ease.
   - [4.9 Using custom deserializers](#using-custom-deserializers)
   - [4.10 Using AVRO deserializer](#using-avro-deserializer)
   - [4.11 Using auto-commit](#using-auto-commit)
-  - [4.12 Setting kafka consumer configuration options](#setting-kafka-configuration-options)
-  - [4.13 Building the consumer](#building-the-consumer)
-  - [4.14 Consuming the kafka message](#consuming-the-kafka-messages)
+  - [4.12 Using custom committers](#using-custom-committers)
+  - [4.13 Setting kafka consumer configuration options](#setting-kafka-configuration-options)
+  - [4.14 Building the consumer](#building-the-consumer)
+  - [4.15 Consuming the kafka message](#consuming-the-kafka-messages)
 - [5. Using custom serializers/deserializers](#using-custom-serializersdeserializers)
 - [6. Using `Kafka::fake()`method](#using-kafkafake)
   - [6.1 `assertPublished` method](#assertpublished-method)
@@ -473,6 +474,42 @@ use the `withAutoCommit` method:
 
 ```php
 $consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->withAutoCommit();
+```
+
+<a name="using-custom-committers"></a>
+## Using custom committers
+By default the committers provided by the `DefaultCommitterFactory` are provided.
+
+To set a custom committer on your consumer, add the committer via a factory that implements the `CommitterFactory` interface:
+
+```php
+use \RdKafka\KafkaConsumer;
+use \RdKafka\Message;
+use \Junges\Kafka\Commit\Contracts\Committer;
+use \Junges\Kafka\Commit\Contracts\CommitterFactory;
+use \Junges\Kafka\Config\Config;
+
+class MyCommitter implements Committer
+{
+    public function commitMessage(Message $message, bool $success) : void {
+        // ...
+    }
+    
+    public function commitDlq(Message $message) : void {
+        // ...
+    }  
+}
+
+class MyCommitterFactory implements CommitterFactory
+{
+    public function make(KafkaConsumer $kafkaConsumer, Config $config) : Committer {
+        // ...
+    }
+}
+
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()
+    ->usingCommitterFactory(new MyCommitterFactory())
+    ->build();
 ```
 
 ## Setting Kafka configuration options

--- a/src/Commit/BatchCommitter.php
+++ b/src/Commit/BatchCommitter.php
@@ -4,6 +4,7 @@ namespace Junges\Kafka\Commit;
 
 use Junges\Kafka\Commit\Contracts\Committer;
 use Junges\Kafka\MessageCounter;
+use RdKafka\Message;
 
 class BatchCommitter implements Committer
 {
@@ -16,11 +17,11 @@ class BatchCommitter implements Committer
     ) {
     }
 
-    public function commitMessage(): void
+    public function commitMessage(Message $message, bool $success): void
     {
         $this->commits++;
         if ($this->maxMessagesLimitReached() || $this->commits >= $this->batchSize) {
-            $this->committer->commitMessage();
+            $this->committer->commitMessage($message, $success);
             $this->commits = 0;
         }
     }
@@ -30,9 +31,9 @@ class BatchCommitter implements Committer
         return $this->messageCounter->maxMessagesLimitReached();
     }
 
-    public function commitDlq(): void
+    public function commitDlq(Message $message): void
     {
-        $this->committer->commitDlq();
+        $this->committer->commitDlq($message);
         $this->commits = 0;
     }
 }

--- a/src/Commit/Contracts/Committer.php
+++ b/src/Commit/Contracts/Committer.php
@@ -2,9 +2,11 @@
 
 namespace Junges\Kafka\Commit\Contracts;
 
+use RdKafka\Message;
+
 interface Committer
 {
-    public function commitMessage(): void;
+    public function commitMessage(Message $message, bool $success): void;
 
-    public function commitDlq(): void;
+    public function commitDlq(Message $message): void;
 }

--- a/src/Commit/Contracts/CommitterFactory.php
+++ b/src/Commit/Contracts/CommitterFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Junges\Kafka\Commit\Contracts;
+
+use Junges\Kafka\Config\Config;
+use RdKafka\KafkaConsumer;
+
+interface CommitterFactory
+{
+    public function make(KafkaConsumer $kafkaConsumer, Config $config): Committer;
+}

--- a/src/Commit/DefaultCommitterFactory.php
+++ b/src/Commit/DefaultCommitterFactory.php
@@ -3,11 +3,12 @@
 namespace Junges\Kafka\Commit;
 
 use Junges\Kafka\Commit\Contracts\Committer;
+use Junges\Kafka\Commit\Contracts\CommitterFactory;
 use Junges\Kafka\Config\Config;
 use Junges\Kafka\MessageCounter;
 use RdKafka\KafkaConsumer;
 
-class CommitterFactory
+class DefaultCommitterFactory implements CommitterFactory
 {
     public function __construct(private MessageCounter $messageCounter)
     {

--- a/src/Commit/KafkaCommitter.php
+++ b/src/Commit/KafkaCommitter.php
@@ -4,6 +4,7 @@ namespace Junges\Kafka\Commit;
 
 use Junges\Kafka\Commit\Contracts\Committer;
 use RdKafka\KafkaConsumer;
+use RdKafka\Message;
 
 class KafkaCommitter implements Committer
 {
@@ -14,16 +15,16 @@ class KafkaCommitter implements Committer
     /**
      * @throws \RdKafka\Exception
      */
-    public function commitMessage(): void
+    public function commitMessage(Message $message, bool $success): void
     {
-        $this->consumer->commit();
+        $this->consumer->commit($message);
     }
 
     /**
      * @throws \RdKafka\Exception
      */
-    public function commitDlq(): void
+    public function commitDlq(Message $message): void
     {
-        $this->consumer->commit();
+        $this->consumer->commit($message);
     }
 }

--- a/src/Commit/RetryableCommitter.php
+++ b/src/Commit/RetryableCommitter.php
@@ -6,6 +6,7 @@ use JetBrains\PhpStorm\Pure;
 use Junges\Kafka\Commit\Contracts\Committer;
 use Junges\Kafka\Commit\Contracts\Sleeper;
 use Junges\Kafka\Retryable;
+use RdKafka\Message;
 
 class RetryableCommitter implements Committer
 {
@@ -31,16 +32,16 @@ class RetryableCommitter implements Committer
     /**
      * @throws \Carbon\Exceptions\Exception
      */
-    public function commitMessage(): void
+    public function commitMessage(Message $message, bool $success): void
     {
-        $this->retryable->retry(fn () => $this->committer->commitMessage());
+        $this->retryable->retry(fn () => $this->committer->commitMessage($message, $success));
     }
 
     /**
      * @throws \Carbon\Exceptions\Exception
      */
-    public function commitDlq(): void
+    public function commitDlq(Message $message): void
     {
-        $this->retryable->retry(fn () => $this->committer->commitDlq());
+        $this->retryable->retry(fn () => $this->committer->commitDlq($message));
     }
 }

--- a/src/Commit/SeekToCurrentErrorCommitter.php
+++ b/src/Commit/SeekToCurrentErrorCommitter.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Junges\Kafka\Commit;
+
+use Junges\Kafka\Commit\Contracts\Committer;
+use RdKafka\KafkaConsumer;
+use RdKafka\Message;
+
+class SeekToCurrentErrorCommitter implements Committer
+{
+    public function __construct(private KafkaConsumer $consumer, private Committer $committer)
+    {
+    }
+
+    public function commitMessage(Message $message, bool $success): void
+    {
+        if ($success) {
+            $this->committer->commitMessage($message, $success);
+
+            return;
+        }
+
+        $currentSubscriptions = $this->consumer->getSubscription();
+        $this->consumer->unsubscribe();
+        $this->consumer->subscribe($currentSubscriptions);
+    }
+
+    public function commitDlq(Message $message): void
+    {
+        $this->committer->commitDlq($message);
+    }
+}

--- a/src/Commit/VoidCommitter.php
+++ b/src/Commit/VoidCommitter.php
@@ -3,14 +3,15 @@
 namespace Junges\Kafka\Commit;
 
 use Junges\Kafka\Commit\Contracts\Committer;
+use RdKafka\Message;
 
 class VoidCommitter implements Committer
 {
-    public function commitMessage(): void
+    public function commitMessage(Message $message, bool $success): void
     {
     }
 
-    public function commitDlq(): void
+    public function commitDlq(Message $message): void
     {
     }
 }

--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -4,10 +4,10 @@ namespace Junges\Kafka\Consumers;
 
 use Closure;
 use InvalidArgumentException;
+use Junges\Kafka\Commit\Contracts\CommitterFactory;
 use Junges\Kafka\Config\Config;
 use Junges\Kafka\Config\Sasl;
 use Junges\Kafka\Contracts\MessageDeserializer;
-use Junges\Kafka\Facades\Kafka;
 
 class ConsumerBuilder
 {
@@ -25,6 +25,7 @@ class ConsumerBuilder
     private bool $autoCommit;
     private array $options;
     private MessageDeserializer $deserializer;
+    private ?CommitterFactory $committerFactory = null;
 
     /**
      * @param string $brokers
@@ -128,9 +129,16 @@ class ConsumerBuilder
         return $this;
     }
 
-    public function usingDeserializer(MessageDeserializer $deserializer)
+    public function usingDeserializer(MessageDeserializer $deserializer): self
     {
         $this->deserializer = $deserializer;
+
+        return $this;
+    }
+
+    public function usingCommitterFactory(CommitterFactory $committerFactory): self
+    {
+        $this->committerFactory = $committerFactory;
 
         return $this;
     }
@@ -265,7 +273,7 @@ class ConsumerBuilder
             customOptions: $this->options
         );
 
-        return new Consumer($config, $this->deserializer);
+        return new Consumer($config, $this->deserializer, $this->committerFactory);
     }
 
     private function validateTopic(mixed $topic)

--- a/tests/Commit/BatchCommitterTest.php
+++ b/tests/Commit/BatchCommitterTest.php
@@ -6,6 +6,7 @@ use Junges\Kafka\Commit\BatchCommitter;
 use Junges\Kafka\Commit\Contracts\Committer;
 use Junges\Kafka\MessageCounter;
 use Junges\Kafka\Tests\LaravelKafkaTestCase;
+use RdKafka\Message;
 
 class BatchCommitterTest extends LaravelKafkaTestCase
 {
@@ -14,14 +15,18 @@ class BatchCommitterTest extends LaravelKafkaTestCase
         $committer = $this->createMock(Committer::class);
         $committer
             ->expects($this->exactly(2))
-            ->method('commitMessage');
+            ->method('commitMessage')
+            ->withConsecutive(
+                [$this->isInstanceOf(Message::class), true],
+                [$this->isInstanceOf(Message::class), true]
+            );
 
         $batchSize = 3;
         $messageCounter = new MessageCounter(42);
         $batchCommitter = new BatchCommitter($committer, $messageCounter, $batchSize);
 
         for ($i = 0; $i < 7; $i++) {
-            $batchCommitter->commitMessage();
+            $batchCommitter->commitMessage(new Message(), true);
         }
     }
 
@@ -37,7 +42,7 @@ class BatchCommitterTest extends LaravelKafkaTestCase
         $messageCounter = new MessageCounter(42);
         $batchCommitter = new BatchCommitter($committer, $messageCounter, $batchSize);
 
-        $batchCommitter->commitDlq();
-        $batchCommitter->commitDlq();
+        $batchCommitter->commitDlq(new Message());
+        $batchCommitter->commitDlq(new Message());
     }
 }

--- a/tests/Commit/CommitterFactoryTest.php
+++ b/tests/Commit/CommitterFactoryTest.php
@@ -3,7 +3,7 @@
 namespace Junges\Kafka\Tests\Commit;
 
 use Junges\Kafka\Commit\BatchCommitter;
-use Junges\Kafka\Commit\CommitterFactory;
+use Junges\Kafka\Commit\DefaultCommitterFactory;
 use Junges\Kafka\Commit\KafkaCommitter;
 use Junges\Kafka\Commit\NativeSleeper;
 use Junges\Kafka\Commit\RetryableCommitter;
@@ -36,7 +36,7 @@ class CommitterFactoryTest extends LaravelKafkaTestCase
 
         $messageCounter = new MessageCounter(6);
 
-        $factory = new CommitterFactory($messageCounter);
+        $factory = new DefaultCommitterFactory($messageCounter);
 
         $committer = $factory->make($consumer, $config);
 
@@ -75,7 +75,7 @@ class CommitterFactoryTest extends LaravelKafkaTestCase
 
         $messageCounter = new MessageCounter(6);
 
-        $factory = new CommitterFactory($messageCounter);
+        $factory = new DefaultCommitterFactory($messageCounter);
 
         $committer = $factory->make($consumer, $config);
 

--- a/tests/Commit/KafkaCommitterTest.php
+++ b/tests/Commit/KafkaCommitterTest.php
@@ -8,6 +8,7 @@ use Junges\Kafka\Tests\LaravelKafkaTestCase;
 use Mockery as m;
 use RdKafka\Conf;
 use RdKafka\KafkaConsumer;
+use RdKafka\Message;
 
 class KafkaCommitterTest extends LaravelKafkaTestCase
 {
@@ -37,7 +38,7 @@ class KafkaCommitterTest extends LaravelKafkaTestCase
             'conf' => $conf,
         ]));
 
-        $kafkaCommitter->commitMessage();
+        $kafkaCommitter->commitMessage(new Message(), true);
     }
 
     public function testItCanCommitToDlq()
@@ -66,6 +67,6 @@ class KafkaCommitterTest extends LaravelKafkaTestCase
             'conf' => $conf,
         ]));
 
-        $kafkaCommitter->commitDlq();
+        $kafkaCommitter->commitDlq(new Message());
     }
 }

--- a/tests/Commit/RetryableCommitterTest.php
+++ b/tests/Commit/RetryableCommitterTest.php
@@ -7,6 +7,7 @@ use Junges\Kafka\Tests\FailingCommitter;
 use Junges\Kafka\Tests\Fakes\FakeSleeper;
 use Junges\Kafka\Tests\LaravelKafkaTestCase;
 use RdKafka\Exception as RdKafkaException;
+use RdKafka\Message;
 
 class RetryableCommitterTest extends LaravelKafkaTestCase
 {
@@ -16,8 +17,8 @@ class RetryableCommitterTest extends LaravelKafkaTestCase
         $failingCommitter = new FailingCommitter($exception, 3);
         $retryableCommitter = new RetryableCommitter($failingCommitter, new FakeSleeper());
 
-        $retryableCommitter->commitMessage();
-        $retryableCommitter->commitDlq();
+        $retryableCommitter->commitMessage(new Message(), false);
+        $retryableCommitter->commitDlq(new Message());
 
         $this->assertEquals(4, $failingCommitter->getTimesTriedToCommitMessage());
         $this->assertEquals(4, $failingCommitter->getTimesTriedToCommitDlq());
@@ -32,7 +33,7 @@ class RetryableCommitterTest extends LaravelKafkaTestCase
         $commitMessageException = null;
 
         try {
-            $retryableCommitter->commitMessage();
+            $retryableCommitter->commitMessage(new Message(), false);
         } catch (RdKafkaException $exception) {
             $commitMessageException = $exception;
         }
@@ -40,7 +41,7 @@ class RetryableCommitterTest extends LaravelKafkaTestCase
         $commitDlqException = null;
 
         try {
-            $retryableCommitter->commitDlq();
+            $retryableCommitter->commitDlq(new Message());
         } catch (RdKafkaException $exception) {
             $commitDlqException = $exception;
         }
@@ -62,7 +63,7 @@ class RetryableCommitterTest extends LaravelKafkaTestCase
         $retryableCommitter = new RetryableCommitter($failingCommitter, $sleeper, 6);
 
         try {
-            $retryableCommitter->commitMessage();
+            $retryableCommitter->commitMessage(new Message(), true);
         } catch (RdKafkaException $exception) {
         }
 

--- a/tests/FailingCommitter.php
+++ b/tests/FailingCommitter.php
@@ -4,6 +4,7 @@ namespace Junges\Kafka\Tests;
 
 use Exception;
 use Junges\Kafka\Commit\Contracts\Committer;
+use RdKafka\Message;
 
 class FailingCommitter implements Committer
 {
@@ -22,7 +23,7 @@ class FailingCommitter implements Committer
     /**
      * @throws \Exception
      */
-    public function commitMessage(): void
+    public function commitMessage(Message $message = null, bool $success = null): void
     {
         $this->timesTriedToCommitMessage++;
         $this->commit();
@@ -31,7 +32,7 @@ class FailingCommitter implements Committer
     /**
      * @throws \Exception
      */
-    public function commitDlq(): void
+    public function commitDlq(Message $message): void
     {
         $this->timesTriedToCommitDlq++;
         $this->commit();


### PR DESCRIPTION
Before it was not possible to add custom committers or custom committer configuration to the consumer, so here is a proposal to add support.

Creating the committers in the consume method instead of injecting via the constructor of `Consumer` makes sense because in some cases you want the `RdKafka\KafkaConsumer` object in the committer. Like the `KafkaCommitter` that was present already, and the `SeekToCurrentErrorCommitter` also needs it.
Hence the extraction of a `CommitterFactory` interface and renaming the `CommitterFactory` class to `DefaultCommitterFactory`.

I've also added the `SeekToCurrentErrorCommitter`, for which I started these changes in the first place. You can use this committer when you need to do in-order processing of messages while blocking the entire stream consumption when one of the messages cannot be processed.
The unsubscribe/subscribe implementation is somewhat hacky. But safe, even with multiple clients in the same consumer group, and across partitions, but probably not very efficient in a setup with multiple clients as this will yield a rebalancing.

I intended all changes in this PR to be fully backwards compatible. Lucky the committers were implicitly private to this library before, because there was no way to set the on the `Consumer`.