### PR TITLE
[1.4.x] Add RetryableHandler

### DIFF
--- a/src/Contracts/RetryStrategy.php
+++ b/src/Contracts/RetryStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Junges\Kafka\Contracts;
+
+interface RetryStrategy
+{
+    public function getMaximumRetries(): int;
+
+    /**
+     * Returns the initial retry delay in seconds
+     *
+     * @return int
+     */
+    public function getInitialDelay(): int;
+
+    public function useExponentialBackoff(): bool;
+}

--- a/src/Contracts/RetryStrategy.php
+++ b/src/Contracts/RetryStrategy.php
@@ -4,14 +4,24 @@ namespace Junges\Kafka\Contracts;
 
 interface RetryStrategy
 {
+    /**
+     * The maximum number of retries
+     *
+     * @return int
+     */
     public function getMaximumRetries(): int;
 
     /**
-     * Returns the initial retry delay in seconds
+     * The initial retry delay in seconds
      *
      * @return int
      */
     public function getInitialDelay(): int;
 
+    /**
+     * Whether to double the initial delay between retries.
+     *
+     * @return bool
+     */
     public function useExponentialBackoff(): bool;
 }

--- a/src/Handlers/RetryStrategies/DefaultRetryStrategy.php
+++ b/src/Handlers/RetryStrategies/DefaultRetryStrategy.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Junges\Kafka\Handlers\RetryStrategies;
+
+use Junges\Kafka\Contracts\RetryStrategy;
+
+class DefaultRetryStrategy implements RetryStrategy
+{
+    public function getMaximumRetries(): int
+    {
+        return 6;
+    }
+
+    public function getInitialDelay(): int
+    {
+        return 1;
+    }
+
+    public function useExponentialBackoff(): bool
+    {
+        return true;
+    }
+}

--- a/src/Handlers/RetryableHandler.php
+++ b/src/Handlers/RetryableHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Junges\Kafka\Handlers;
+
+use Junges\Kafka\Commit\Contracts\Sleeper;
+use Junges\Kafka\Contracts\KafkaConsumerMessage;
+use Junges\Kafka\Contracts\RetryStrategy;
+use Junges\Kafka\Retryable;
+
+class RetryableHandler
+{
+    public function __construct(private \Closure $handler, private RetryStrategy $retryStrategy, private Sleeper $sleeper)
+    {
+    }
+
+    public function __invoke(KafkaConsumerMessage $message): void
+    {
+        $retryable = new Retryable($this->sleeper, $this->retryStrategy->getMaximumRetries(), null);
+        $retryable->retry(
+            fn () => ($this->handler)($message),
+            0,
+            $this->retryStrategy->getInitialDelay(),
+            $this->retryStrategy->useExponentialBackoff()
+        );
+    }
+}

--- a/src/Handlers/RetryableHandler.php
+++ b/src/Handlers/RetryableHandler.php
@@ -2,6 +2,7 @@
 
 namespace Junges\Kafka\Handlers;
 
+use Closure;
 use Junges\Kafka\Commit\Contracts\Sleeper;
 use Junges\Kafka\Contracts\KafkaConsumerMessage;
 use Junges\Kafka\Contracts\RetryStrategy;
@@ -9,7 +10,7 @@ use Junges\Kafka\Retryable;
 
 class RetryableHandler
 {
-    public function __construct(private \Closure $handler, private RetryStrategy $retryStrategy, private Sleeper $sleeper)
+    public function __construct(private Closure $handler, private RetryStrategy $retryStrategy, private Sleeper $sleeper)
     {
     }
 

--- a/tests/FailingHandler.php
+++ b/tests/FailingHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Junges\Kafka\Tests;
+
+use Exception;
+use Junges\Kafka\Contracts\KafkaConsumerMessage;
+
+class FailingHandler
+{
+    private int $timesInvoked = 0;
+
+    public function __construct(private int $timesToFail, private Exception $exception)
+    {
+    }
+
+    public function __invoke(KafkaConsumerMessage $message): void
+    {
+        if ($this->timesInvoked++ < $this->timesToFail) {
+            throw $this->exception;
+        }
+    }
+
+    public function getTimesInvoked(): int
+    {
+        return $this->timesInvoked;
+    }
+}

--- a/tests/Handlers/RetryableHandlerTest.php
+++ b/tests/Handlers/RetryableHandlerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Junges\Kafka\Tests\Handlers;
+
+use Junges\Kafka\Contracts\KafkaConsumerMessage;
+use Junges\Kafka\Handlers\RetryableHandler;
+use Junges\Kafka\Handlers\RetryStrategies\DefaultRetryStrategy;
+use Junges\Kafka\Tests\FailingHandler;
+use Junges\Kafka\Tests\Fakes\FakeSleeper;
+use PHPUnit\Framework\TestCase;
+
+class RetryableHandlerTest extends TestCase
+{
+    public function testItPassesWhenNoExceptionOccurred(): void
+    {
+        $failingHandler = new FailingHandler(0, new \RuntimeException('test'));
+        $handler = new RetryableHandler(\Closure::fromCallable($failingHandler), new DefaultRetryStrategy(), new FakeSleeper());
+
+        $messageMock = $this->createMock(KafkaConsumerMessage::class);
+        $handler($messageMock);
+
+        $this->assertSame(1, $failingHandler->getTimesInvoked());
+    }
+
+    public function testItDoesRetriesOnException(): void
+    {
+        $failingHandler = new FailingHandler(4, new \RuntimeException('test'));
+        $sleeper = new FakeSleeper();
+        $handler = new RetryableHandler(\Closure::fromCallable($failingHandler), new DefaultRetryStrategy(), $sleeper);
+
+        $messageMock = $this->createMock(KafkaConsumerMessage::class);
+        $handler($messageMock);
+
+        $this->assertSame(5, $failingHandler->getTimesInvoked());
+        $this->assertEquals([1e6, 2e6, 4e6, 8e6], $sleeper->getSleeps());
+    }
+
+    public function testItBubblesExceptionWhenRetriesExceeded(): void
+    {
+        $failingHandler = new FailingHandler(100, new \RuntimeException('test'));
+        $sleeper = new FakeSleeper();
+        $handler = new RetryableHandler(\Closure::fromCallable($failingHandler), new DefaultRetryStrategy(), $sleeper);
+
+        $messageMock = $this->createMock(KafkaConsumerMessage::class);
+
+        try {
+            $handler($messageMock);
+
+            $this->fail('Handler passed but a \RuntimeException is expected.');
+        } catch (\RuntimeException) {
+            $this->assertSame(7, $failingHandler->getTimesInvoked());
+            $this->assertEquals([1e6, 2e6, 4e6, 8e6, 16e6, 32e6], $sleeper->getSleeps());
+        }
+    }
+}


### PR DESCRIPTION
This handler can retry message handling and blocks processing any other messages.
This is helpful when you want to process messages in-order, or want to retry handling before sending the message to the DLQ.

I've also made the `Retryable::$retryableErrors` setting nullable, allowing retries for any exception.

**Example usage:**

```php
$handler = function(KafkaConsumerMessage $message) {
    Log::debug('Received message:', ['message' => $message->getBody()]);

    throw new \RuntimeException('test');
};

$retryableHandler = new RetryableHandler($handler, new DefaultRetryStrategy(), new NativeSleeper());
$kafkaConsumer = Kafka::createConsumer()
    ->withHandler($retryableHandler)
    ->build();
```

This would retry to handle the message 6 times. After that it is recognised as failed by the exception handler/executeMessage method.