### PR TITLE
[1.5.x] Small exception improvements

### DIFF
--- a/src/Exceptions/LaravelKafkaException.php
+++ b/src/Exceptions/LaravelKafkaException.php
@@ -4,6 +4,6 @@ namespace Junges\Kafka\Exceptions;
 
 use Exception;
 
-class LaravelKafkaException extends Exception
+abstract class LaravelKafkaException extends Exception
 {
 }

--- a/src/Exceptions/SchemaRegistryException.php
+++ b/src/Exceptions/SchemaRegistryException.php
@@ -2,9 +2,7 @@
 
 namespace Junges\Kafka\Exceptions;
 
-use RuntimeException;
-
-class SchemaRegistryException extends RuntimeException
+class SchemaRegistryException extends LaravelKafkaException
 {
     public const SCHEMA_MAPPING_NOT_FOUND = 'There is no schema mapping topic: %s, type: %s';
 }

--- a/src/Exceptions/Serializers/AvroSerializerException.php
+++ b/src/Exceptions/Serializers/AvroSerializerException.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Junges\Kafka\Exceptions\Encoders;
+namespace Junges\Kafka\Exceptions\Serializers;
 
-use RuntimeException;
+use Junges\Kafka\Exceptions\LaravelKafkaException;
 
-class AvroEncoderException extends RuntimeException
+class AvroSerializerException extends LaravelKafkaException
 {
     public const NO_SCHEMA_FOR_TOPIC_MESSAGE = 'There is no %s avro schema defined for the topic %s';
     public const UNABLE_TO_LOAD_DEFINITION_MESSAGE = 'Was unable to load definition for schema %s';

--- a/src/Message/Serializers/AvroSerializer.php
+++ b/src/Message/Serializers/AvroSerializer.php
@@ -8,7 +8,7 @@ use Junges\Kafka\Contracts\AvroMessageSerializer;
 use Junges\Kafka\Contracts\AvroSchemaRegistry;
 use Junges\Kafka\Contracts\KafkaAvroSchemaRegistry;
 use Junges\Kafka\Contracts\KafkaProducerMessage;
-use Junges\Kafka\Exceptions\Encoders\AvroEncoderException;
+use Junges\Kafka\Exceptions\Serializers\AvroSerializerException;
 
 class AvroSerializer implements AvroMessageSerializer
 {
@@ -83,9 +83,9 @@ class AvroSerializer implements AvroMessageSerializer
         $schemaDefinition = $avroSchema->getDefinition();
 
         if (null === $schemaDefinition) {
-            throw new AvroEncoderException(
+            throw new AvroSerializerException(
                 sprintf(
-                    AvroEncoderException::UNABLE_TO_LOAD_DEFINITION_MESSAGE,
+                    AvroSerializerException::UNABLE_TO_LOAD_DEFINITION_MESSAGE,
                     $avroSchema->getName()
                 )
             );

--- a/tests/Message/Serializers/AvroSerializerTest.php
+++ b/tests/Message/Serializers/AvroSerializerTest.php
@@ -6,7 +6,7 @@ use FlixTech\AvroSerializer\Objects\RecordSerializer;
 use Junges\Kafka\Contracts\AvroSchemaRegistry;
 use Junges\Kafka\Contracts\KafkaAvroSchemaRegistry;
 use Junges\Kafka\Contracts\KafkaProducerMessage;
-use Junges\Kafka\Exceptions\Encoders\AvroEncoderException;
+use Junges\Kafka\Exceptions\Serializers\AvroSerializerException;
 use Junges\Kafka\Message\Serializers\AvroSerializer;
 use Junges\Kafka\Tests\LaravelKafkaTestCase;
 
@@ -46,10 +46,10 @@ class AvroSerializerTest extends LaravelKafkaTestCase
         $registry->expects($this->once())->method('hasBodySchemaForTopic')->willReturn(true);
         $registry->expects($this->once())->method('getBodySchemaForTopic')->willReturn($avroSchema);
 
-        $this->expectException(AvroEncoderException::class);
+        $this->expectException(AvroSerializerException::class);
         $this->expectExceptionMessage(
             sprintf(
-                AvroEncoderException::UNABLE_TO_LOAD_DEFINITION_MESSAGE,
+                AvroSerializerException::UNABLE_TO_LOAD_DEFINITION_MESSAGE,
                 $avroSchema->getName()
             )
         );


### PR DESCRIPTION
Renamed the Avro exception as mentioned in https://github.com/mateusjunges/laravel-kafka/pull/31#issuecomment-982725715.
Also, this PR lets all exceptions extend from the base `LaravelKafkaException`, which is now `abstract`.

**Backwards compatibility breaks:**
- `Junges\Kafka\Exceptions\Encoders\AvroEncoderException` is renamed to `Junges\Kafka\Exceptions\Serializers\AvroSerializerException`

As you mentioned @mateusjunges, this change is pending for the next minor version.