### PR TITLE
[1.5.x] Consumer API improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All relevant changes to `mateusjunges/laravel-kafka` will be documented here.
 
+## [2021-12-xx v1.5.1](https://github.com/mateusjunges/laravel-kafka/compare/v1.5.0...v1.5.1)
+### Added
+- Added a `withBrokers` setter to the consumer api, allowing to set brokers on the run ([#6a639ce](https://github.com/mateusjunges/laravel-kafka/commit/6a639ce3670ef1df25c79d11923fcb13b37d4f8f))
+- Added boolean argument to `withAutoCommit`, which defaults to true ([#3ffb226](https://github.com/mateusjunges/laravel-kafka/commit/3ffb2265b0abd46e2d7048f55f9982bfedd441e2))
+
+### Fixed
+- Cast `auto_commit` to string on initial consumer options ([#f2a6c2b](https://github.com/mateusjunges/laravel-kafka/commit/f2a6c2b30d1180347f423df18132a90024c7b542))
+
 ## [2021-12-08 v1.5.0](https://github.com/mateusjunges/laravel-kafka/compare/v1.4.5...v1.5.0)
 ### Changed
 - Renamed `AvroencoderException` to `AvroSerializerException` by @rtuin in [#38](https://github.com/mateusjunges/laravel-kafka/pull/38)

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ class Handler
     }
 }
 
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->withHandler(Handler::class)
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->withHandler(new Handler)
 ```
 
 The `KafkaConsumerMessage` contract gives you some handy methods to get the message properties: 
@@ -357,7 +357,7 @@ function gracefulShutdown(Consumer $consumer) {
 
 $consumer = Kafka::createConsumer(['topic'])
     ->withConsumerGroupId('group')
-    ->withHandler(Handler::class)
+    ->withHandler(new Handler)
     ->build();
     
 pcntl_signal(SIGINT, fn() => gracefulShutdown($consumer));

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ syntax usage syntax or, if it does, the test process with these packages are ver
 
 This package provides a nice way of producing and consuming kafka messages in your Laravel projects.
 
-Follow these docs to install this package and start using kafka with ease.
+Follow these docs to install this package and start using kafka in your laravel projects.
 
 - [1. Installation](#installation)
 - [2. Usage](#usage)

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -69,8 +69,8 @@ class Config
             'bootstrap.servers' => $this->broker,
         ];
 
-        if ($this->autoCommit) {
-            $options['enable.auto.commit'] = 'true';
+        if (! empty($this->autoCommit)) {
+            $options['enable.auto.commit'] = $this->autoCommit === true ? 'true' : 'false';
         }
 
         return array_merge($options, $this->customOptions);

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -69,7 +69,7 @@ class Config
             'bootstrap.servers' => $this->broker,
         ];
 
-        if (! empty($this->autoCommit)) {
+        if (isset($this->autoCommit)) {
             $options['enable.auto.commit'] = $this->autoCommit === true ? 'true' : 'false';
         }
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -63,7 +63,7 @@ class Config
         $options = [
             'metadata.broker.list' => $this->broker,
             'auto.offset.reset' => config('kafka.offset_reset', 'latest'),
-            'enable.auto.commit' => config('kafka.auto_commit', 'true'),
+            'enable.auto.commit' => config('kafka.auto_commit', true) === true ? 'true' : 'false',
             'compression.codec' => config('kafka.compression', 'snappy'),
             'group.id' => $this->groupId,
             'bootstrap.servers' => $this->broker,

--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -265,9 +265,9 @@ class ConsumerBuilder
      *
      * @return $this
      */
-    public function withAutoCommit(): self
+    public function withAutoCommit(bool $autoCommit = true): self
     {
-        $this->autoCommit = true;
+        $this->autoCommit = $autoCommit;
 
         return $this;
     }

--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -97,6 +97,19 @@ class ConsumerBuilder
     }
 
     /**
+     * Set the brokers the kafka consumer should use.
+     *
+     * @param string $brokers
+     * @return $this
+     */
+    public function withBrokers(string $brokers): self
+    {
+        $this->brokers = $brokers;
+
+        return $this;
+    }
+
+    /**
      * @param string $groupId
      * @return $this
      */

--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -101,12 +101,12 @@ class ConsumerBuilder
     /**
      * Set the brokers the kafka consumer should use.
      *
-     * @param string $brokers
+     * @param ?string $brokers
      * @return $this
      */
-    public function withBrokers(string $brokers): self
+    public function withBrokers(?string $brokers): self
     {
-        $this->brokers = $brokers;
+        $this->brokers = $brokers ?? config('kafka.brokers');
 
         return $this;
     }
@@ -114,10 +114,10 @@ class ConsumerBuilder
     /**
      * Specify the consumer group id.
      *
-     * @param string $groupId
+     * @param ?string $groupId
      * @return $this
      */
-    public function withConsumerGroupId(string $groupId): self
+    public function withConsumerGroupId(?string $groupId): self
     {
         $this->groupId = $groupId;
 

--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -59,6 +59,8 @@ class ConsumerBuilder
     }
 
     /**
+     * Creates a new ConsumerBuilder instance.
+     *
      * @param string $brokers
      * @param array $topics
      * @param string|null $groupId
@@ -110,6 +112,8 @@ class ConsumerBuilder
     }
 
     /**
+     * Specify the consumer group id.
+     *
      * @param string $groupId
      * @return $this
      */
@@ -121,6 +125,8 @@ class ConsumerBuilder
     }
 
     /**
+     * Specify the commit batch size.
+     *
      * @param int $size
      * @return $this
      */
@@ -132,6 +138,8 @@ class ConsumerBuilder
     }
 
     /**
+     * Specify the class used to handle consumed messages.
+     *
      * @param callable $handler
      * @return $this
      */
@@ -142,6 +150,12 @@ class ConsumerBuilder
         return $this;
     }
 
+    /**
+     * Specify the class that should be used to deserialize messages.
+     *
+     * @param MessageDeserializer $deserializer
+     * @return $this
+     */
     public function usingDeserializer(MessageDeserializer $deserializer): self
     {
         $this->deserializer = $deserializer;
@@ -149,6 +163,12 @@ class ConsumerBuilder
         return $this;
     }
 
+    /**
+     * Specify the factory that should be used to build the committer.
+     *
+     * @param CommitterFactory $committerFactory
+     * @return $this
+     */
     public function usingCommitterFactory(CommitterFactory $committerFactory): self
     {
         $this->committerFactory = $committerFactory;
@@ -157,6 +177,8 @@ class ConsumerBuilder
     }
 
     /**
+     * Define the max number of messages that should be consumed.
+     *
      * @param int $maxMessages
      * @return $this
      */
@@ -168,6 +190,8 @@ class ConsumerBuilder
     }
 
     /**
+     * Specify the max retries attempts.
+     *
      * @param int $maxCommitRetries
      * @return $this
      */
@@ -196,6 +220,8 @@ class ConsumerBuilder
     }
 
     /**
+     * Set the Sals configuration.
+     *
      * @param Sasl $saslConfig
      * @return $this
      */
@@ -207,8 +233,8 @@ class ConsumerBuilder
     }
 
     /**
+     * Specify middlewares to be executed before handling the message.
      * The middlewares get executed in the order they are defined.
-     *
      * The middleware is a callable in which the first argument is the message itself and the second is the next handler
      *
      * @param callable(mixed, callable): void $middleware
@@ -222,6 +248,8 @@ class ConsumerBuilder
     }
 
     /**
+     * Specify the security protocol that should be used.
+     *
      * @param string $securityProtocol
      * @return $this
      */
@@ -233,6 +261,8 @@ class ConsumerBuilder
     }
 
     /**
+     * Enable or disable consumer auto commit option.
+     *
      * @return $this
      */
     public function withAutoCommit(): self
@@ -244,6 +274,7 @@ class ConsumerBuilder
 
     /**
      * Set the configuration options.
+     *
      * @param array $options
      * @return $this
      */
@@ -258,6 +289,7 @@ class ConsumerBuilder
 
     /**
      * Set a specific configuration option.
+     *
      * @param string $name
      * @param string $value
      * @return $this
@@ -269,6 +301,11 @@ class ConsumerBuilder
         return $this;
     }
 
+    /**
+     * Build the Kafka consumer.
+     *
+     * @return Consumer
+     */
     public function build(): Consumer
     {
         $config = new Config(
@@ -289,6 +326,12 @@ class ConsumerBuilder
         return new Consumer($config, $this->deserializer, $this->committerFactory);
     }
 
+    /**
+     * Validates each topic before subscribing.
+     *
+     * @param mixed $topic
+     * @return void
+     */
     private function validateTopic(mixed $topic)
     {
         if (! is_string($topic)) {

--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -220,7 +220,7 @@ class ConsumerBuilder
     }
 
     /**
-     * Set the Sals configuration.
+     * Set the Sasl configuration.
      *
      * @param Sasl $saslConfig
      * @return $this

--- a/tests/Consumers/ConsumerBuilderTest.php
+++ b/tests/Consumers/ConsumerBuilderTest.php
@@ -226,6 +226,14 @@ class ConsumerBuilderTest extends LaravelKafkaTestCase
         $autoCommit = $this->getPropertyWithReflection('autoCommit', $consumer);
 
         $this->assertTrue($autoCommit);
+
+        $consumer = ConsumerBuilder::create('broker')->withAutoCommit(false);
+
+        $this->assertInstanceOf(Consumer::class, $consumer->build());
+
+        $autoCommit = $this->getPropertyWithReflection('autoCommit', $consumer);
+
+        $this->assertFalse($autoCommit);
     }
 
     public function testItCanSetConsumerOptions()

--- a/tests/Consumers/ConsumerBuilderTest.php
+++ b/tests/Consumers/ConsumerBuilderTest.php
@@ -247,6 +247,17 @@ class ConsumerBuilderTest extends LaravelKafkaTestCase
         $this->assertEquals('false', $options['enable.auto.commit']);
     }
 
+    public function testItCanSpecifyBrokersUsingWithBrokers()
+    {
+        $consumer = ConsumerBuilder::create('broker')->withBrokers('my-test-broker');
+
+        $this->assertInstanceOf(Consumer::class, $consumer->build());
+
+        $brokers = $this->getPropertyWithReflection('brokers', $consumer);
+
+        $this->assertEquals('my-test-broker', $brokers);
+    }
+
     public function testItCanBuildWithCustomCommitter(): void
     {
         $adhocCommitterFactory = new class implements CommitterFactory {


### PR DESCRIPTION
This PR adds a `withBrokers` setter to the Consumer API.
It also makes the `withAutoCommit` accept a `bool` argument to set the `auto_commit` to false, so instead of doing 
```php 
$consumer = Kafka::createConsumer(brokers: $config['brokers']);

if ($config['auto_commit']) {
   $consumer->withAutoCommit();
}
``` 

you can do 
```php
$consumer = Kafka::createConsumer(brokers: $config['brokers'])->withAutoCommit($config['auto_commit']);
```
I've fixed `getConsumerOptions` to use correct `auto_commit` option and fixed the `auto_commit` option in the initial Consumer options array, to be casted to string.
