### PR TITLE
[1.5.x] Adds support for `librdkafka` v0.11.3

### DIFF
--- a/src/Producers/Producer.php
+++ b/src/Producers/Producer.php
@@ -53,13 +53,22 @@ class Producer
 
         $message = $this->serializer->serialize($message);
 
-        $topic->producev(
-            partition: $message->getPartition(),
-            msgflags: RD_KAFKA_MSG_F_BLOCK,
-            payload: $message->getBody(),
-            key: $message->getKey(),
-            headers: $message->getHeaders()
-        );
+        if (method_exists($topic, 'producev')) {
+            $topic->producev(
+                partition: $message->getPartition(),
+                msgflags: RD_KAFKA_MSG_F_BLOCK,
+                payload: $message->getBody(),
+                key: $message->getKey(),
+                headers: $message->getHeaders()
+            );
+        } else {
+            $topic->produce(
+                partition: $message->getPartition(),
+                msgflags: 0,
+                payload: $message->getBody(),
+                key: $message->getKey()
+            );
+        }
 
         $this->producer->poll(0);
 

--- a/tests/KafkaTest.php
+++ b/tests/KafkaTest.php
@@ -12,16 +12,21 @@ use Junges\Kafka\Message\Serializers\NullSerializer;
 use Junges\Kafka\Producers\ProducerBuilder;
 use Mockery as m;
 use RdKafka\Producer;
+use RdKafka\ProducerTest;
+use RdKafka\ProducerTopic;
 
 class KafkaTest extends LaravelKafkaTestCase
 {
     public function testItCanPublishMessagesToKafka()
     {
+        $mockedProducerTopic = m::mock(ProducerTopic::class)
+            ->shouldReceive('producev')->once()
+            ->andReturn(m::self())
+            ->getMock();
+
         $mockedProducer = m::mock(Producer::class)
             ->shouldReceive('newTopic')
-            ->andReturn(m::self())
-            ->shouldReceive('producev')
-            ->andReturn(m::self())
+            ->andReturn($mockedProducerTopic)
             ->shouldReceive('poll')
             ->andReturn(m::self())
             ->shouldReceive('flush')
@@ -47,11 +52,14 @@ class KafkaTest extends LaravelKafkaTestCase
 
     public function testICanSwitchSerializersOnTheFly()
     {
+        $mockedProducerTopic = m::mock(ProducerTopic::class)
+            ->shouldReceive('producev')->once()
+            ->andReturn(m::self())
+            ->getMock();
+
         $mockedProducer = m::mock(Producer::class)
             ->shouldReceive('newTopic')
-            ->andReturn(m::self())
-            ->shouldReceive('producev')
-            ->andReturn(m::self())
+            ->andReturn($mockedProducerTopic)
             ->shouldReceive('poll')
             ->andReturn(m::self())
             ->shouldReceive('flush')
@@ -112,11 +120,14 @@ class KafkaTest extends LaravelKafkaTestCase
 
     public function testICanSetTheEntireMessageWithMessageObject()
     {
+        $mockedProducerTopic = m::mock(ProducerTopic::class)
+            ->shouldReceive('producev')->times(2)
+            ->andReturn(m::self())
+            ->getMock();
+
         $mockedProducer = m::mock(Producer::class)
             ->shouldReceive('newTopic')
-            ->andReturn(m::self())
-            ->shouldReceive('producev')
-            ->andReturn(m::self())
+            ->andReturn($mockedProducerTopic)
             ->shouldReceive('poll')
             ->andReturn(m::self())
             ->shouldReceive('flush')
@@ -156,11 +167,14 @@ class KafkaTest extends LaravelKafkaTestCase
 
     public function testICanDisableDebugUsingWithDebugDisabledMethod()
     {
+        $mockedProducerTopic = m::mock(ProducerTopic::class)
+            ->shouldReceive('producev')->once()
+            ->andReturn(m::self())
+            ->getMock();
+
         $mockedProducer = m::mock(Producer::class)
             ->shouldReceive('newTopic')
-            ->andReturn(m::self())
-            ->shouldReceive('producev')
-            ->andReturn(m::self())
+            ->andReturn($mockedProducerTopic)
             ->shouldReceive('poll')
             ->andReturn(m::self())
             ->shouldReceive('flush')
@@ -233,11 +247,14 @@ class KafkaTest extends LaravelKafkaTestCase
 
         $this->expectExceptionMessage("Sent messages may not be completed yet.");
 
+        $mockedProducerTopic = m::mock(ProducerTopic::class)
+            ->shouldReceive('producev')->once()
+            ->andReturn(m::self())
+            ->getMock();
+
         $mockedProducer = m::mock(Producer::class)
             ->shouldReceive('newTopic')
-            ->andReturn(m::self())
-            ->shouldReceive('producev')
-            ->andReturn(m::self())
+            ->andReturn($mockedProducerTopic)
             ->shouldReceive('poll')
             ->andReturn(m::self())
             ->shouldReceive('flush')


### PR DESCRIPTION
This PR adds support for librdkafka under v0.11.4, which does not support the usage of `producev` method and fix some mocks in tests.