### PR TITLE
[2.x] Replace test docker image + PHP 8.1 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.1, 8.0]
+        php: ["8.1", "8.0"]
         librdkafka: [v1.6.0, v1.6.1, v1.6.2, v1.7.0, v1.8.0, v1.8.2]
         extrdkafka: [5.0.0, 5.0.1, 5.0.2]
         laravel: [8]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.1, 8.0]
+        php: ["8.1", "8.0"]
         librdkafka: [v1.6.0, v1.6.1, v1.6.2, v1.7.0, v1.8.0 v1.8.2]
         extrdkafka: [5.0.0, 5.0.1, 5.0.2]
         laravel: [8]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         php: [8.1]
-        librdkafka: [v1.7.0]
-        extrdkafka: [5.0.0]
+        librdkafka: [v1.8.2]
+        extrdkafka: [5.0.2]
         laravel: [8]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
             extrdkafka: 5.0.0
           - php: 8.0
             librdkafka: v1.7.0
-            extrdkafka: 5.0.0, 5.0.1
+            extrdkafka: 5.0.1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,6 +18,9 @@ jobs:
         exclude:
           - php: 8.1
             extrdkafka: 5.0.0
+          - php: 8.0
+          - librdkafka: v1.7.0
+            extrdkafka: 5.0.0, 5.0.1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php: ["8.1", "8.0"]
-        librdkafka: [v1.6.0, v1.6.1, v1.6.2, v1.7.0, v1.8.0 v1.8.2]
+        librdkafka: [v1.6.0, v1.6.1, v1.6.2, v1.7.0, v1.8.0, v1.8.2]
         extrdkafka: [5.0.0, 5.0.1, 5.0.2]
         laravel: [8]
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ["8.0"]
+        php: [8.1]
         librdkafka: [v1.7.0]
         extrdkafka: [5.0.0]
         laravel: [8]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
           - php: 8.1
             extrdkafka: 5.0.0
           - php: 8.0
-          - librdkafka: v1.7.0
+            librdkafka: v1.7.0
             extrdkafka: 5.0.0, 5.0.1
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.1]
-        librdkafka: [v1.8.2]
-        extrdkafka: [5.0.2]
+        php: [8.1, 8.0]
+        librdkafka: [v1.6.0, v1.6.1, v1.6.2, v1.7.0, v1.8.0 v1.8.2]
+        extrdkafka: [5.0.0, 5.0.1, 5.0.2]
         laravel: [8]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,10 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ["8.1", "8.0"]
+        php: [8.1, 8.0]
         librdkafka: [v1.6.0, v1.6.1, v1.6.2, v1.7.0, v1.8.0, v1.8.2]
         extrdkafka: [5.0.0, 5.0.1, 5.0.2]
         laravel: [8]
+        exclude:
+          - php: 8.1
+            extrdkafka: 5.0.0
+
     steps:
       - uses: actions/checkout@v2
       - name: Test ${{ matrix.php }}-${{ matrix.librdkafka }}-${{ matrix.extrdkafka }}-${{ matrix.laravel }}

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,6 @@ version-test-%:
 	@$(eval PHP_VERSION=$(shell echo ${TAG:0:3}))
 	@$(eval LIBRDKAFKA_VERSION=$(shell echo ${TAG:4:6}))
 	@$(eval EXT_RDKAFKA_VERSION=$(shell echo ${TAG:11:5}))
-	@docker-compose -f docker-compose-test.yaml build --build-arg TAG=${TAG} --build-arg LARAVEL_VERSION=${LARAVEL_VERSION} --build-arg LIBRDKAFKA_VERSION=${LIBRDKAFKA_VERSION} --build-arg EXT_RDKAFKA_VERSION=${EXT_RDKAFKA_VERSION}
+	@docker-compose -f docker-compose-test.yaml build --build-arg PHP_VERSION=${PHP_VERSION} --build-arg TAG=${TAG} --build-arg LARAVEL_VERSION=${LARAVEL_VERSION} --build-arg LIBRDKAFKA_VERSION=${LIBRDKAFKA_VERSION} --build-arg EXT_RDKAFKA_VERSION=${EXT_RDKAFKA_VERSION}
 	@docker-compose -f docker-compose-test.yaml up -d
 	@docker-compose -f docker-compose-test.yaml exec -T test ./vendor/phpunit/phpunit/phpunit tests

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ coverage: up
 
 unit-coverage:
 	@docker-compose exec laravel phpdbg -qrr ./vendor/bin/phpunit tests --whitelist /application/laravel-kafka/src --coverage-html /application/laravel-kafka/coverage --filter Unit
-8.0-v1.6.1-5.0.0-8
+
 integration-coverage:
 	@docker-compose exec laravel phpdbg -qrr ./vendor/bin/phpunit tests --whitelist /application/laravel-kafka/src --coverage-html /application/laravel-kafka/coverage --filter Integration
 

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,16 @@ coverage: up
 
 unit-coverage:
 	@docker-compose exec laravel phpdbg -qrr ./vendor/bin/phpunit tests --whitelist /application/laravel-kafka/src --coverage-html /application/laravel-kafka/coverage --filter Unit
-
+8.0-v1.6.1-5.0.0-8
 integration-coverage:
 	@docker-compose exec laravel phpdbg -qrr ./vendor/bin/phpunit tests --whitelist /application/laravel-kafka/src --coverage-html /application/laravel-kafka/coverage --filter Integration
 
 version-test-%:
 	@$(eval TAG = $(@:version-test-%=%))
 	@$(eval LARAVEL_VERSION=$(shell echo ${TAG} | cut -c18))
-	@docker-compose -f docker-compose-test.yaml build --build-arg TAG=${TAG} --build-arg LARAVEL_VERSION=${LARAVEL_VERSION}
+	@$(eval PHP_VERSION=$(shell echo ${TAG:0:3}))
+	@$(eval LIBRDKAFKA_VERSION=$(shell echo ${TAG:4:6}))
+	@$(eval EXT_RDKAFKA_VERSION=$(shell echo ${TAG:11:5}))
+	@docker-compose -f docker-compose-test.yaml build --build-arg TAG=${TAG} --build-arg LARAVEL_VERSION=${LARAVEL_VERSION} --build-arg LIBRDKAFKA_VERSION=${LIBRDKAFKA_VERSION} --build-arg EXT_RDKAFKA_VERSION=${EXT_RDKAFKA_VERSION}
 	@docker-compose -f docker-compose-test.yaml up -d
 	@docker-compose -f docker-compose-test.yaml exec -T test ./vendor/phpunit/phpunit/phpunit tests

--- a/build/test/Dockerfile
+++ b/build/test/Dockerfile
@@ -1,6 +1,6 @@
 ARG TAG
 
-FROM joesantos386/laravel:${TAG}
+FROM mateusjunges/laravel:${TAG}
 
 ARG LARAVEL_VERSION
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM joesantos386/laravel:8.0-v1.5.3-5.0.0-8
+FROM mateusjunges/laravel:8.0-v1.5.3-5.0.0-8
 
 RUN apk add libzip-dev
 

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -40,6 +40,8 @@ services:
       dockerfile: build/test/Dockerfile
       args:
         TAG: 8.0-v1.6.1-5.0.0-8
+        LIBRDKAFKA_VERSION: v1.6.0
+        EXT_RDKAFKA_VERSION: 5.0.0
         LARAVEL_VERSION: 8
     entrypoint: /application/laravel-kafka/start.sh
     networks:

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -42,6 +42,7 @@ services:
         TAG: 8.0-v1.6.1-5.0.0-8
         LIBRDKAFKA_VERSION: v1.6.0
         EXT_RDKAFKA_VERSION: 5.0.0
+        PHP_VERSION: 8.0
         LARAVEL_VERSION: 8
     entrypoint: /application/laravel-kafka/start.sh
     networks:


### PR DESCRIPTION
This PR adds PHP 8.1 support and replaces the current docker image used for tests.