### PR TITLE
[1.5.x] Include SASL on consumer config when applicable

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -73,7 +73,7 @@ class Config
             $options['enable.auto.commit'] = $this->autoCommit === true ? 'true' : 'false';
         }
 
-        return array_merge($options, $this->customOptions);
+        return array_merge($options, $this->customOptions, $this->getSaslOptions());
     }
 
     #[Pure]

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -69,6 +69,42 @@ class ConfigTest extends LaravelKafkaTestCase
         );
     }
 
+    public function testItUsesSaslConfigWhenSet()
+    {
+        $config = new Config(
+            broker: 'broker',
+            topics: ['topic'],
+            securityProtocol: 'SASL_SSL',
+            commit: 1,
+            groupId: 'group',
+            consumer: $this->createMock(Consumer::class),
+            sasl: new Sasl('foo', 'bar', 'SCRAM-SHA-512', 'SASL_SSL'),
+            dlq: null,
+            maxMessages: -1,
+            maxCommitRetries: 6,
+            autoCommit: true,
+            customOptions: ['auto.offset.reset' => 'smallest', 'compression.codec' => 'gzip']
+        );
+
+        $expectedOptions = [
+            'auto.offset.reset' => 'smallest',
+            'enable.auto.commit' => 'true',
+            'compression.codec' => 'gzip',
+            'group.id' => 'group',
+            'bootstrap.servers' => 'broker',
+            'metadata.broker.list' => 'broker',
+            'security.protocol' => 'SASL_SSL',
+            'sasl.username' => 'foo',
+            'sasl.password' => 'bar',
+            'sasl.mechanisms' => 'SCRAM-SHA-512',
+        ];
+
+        $this->assertEquals(
+            $expectedOptions,
+            $config->getConsumerOptions()
+        );
+    }
+
     public function testItReturnsProducerOptions()
     {
         $sasl = new Sasl(


### PR DESCRIPTION
This is a fix for a bug found while implementing a SASL/SCRAM consumer. The `getConsumerOptions` method didn't include the SASL options.
I found some other small things which I haven't had the time to make a PR for / give as feedback for https://github.com/mateusjunges/laravel-kafka/pull/45. Also some bigger things, for example a refactor of the consumer/producer and related builders to improve extension and mocking abilities.

I wish to free up some time to work on this project, but not expecting much the coming 1-2 weeks.