### PR TITLE
[1.6.x] Fixes #69 - Allow to use SASL with lowercase config keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All relevant changes to `mateusjunges/laravel-kafka` will be documented here.
 
+## [2022-01-20 v1.6.1](https://github.com/mateusjunges/laravel-kafka/compare/v1.6.0...v1.6.1)
+### Fixed
+- Fixes [#69](https://github.com/mateusjunges/laravel-kafka/issues/69)
+
 ## [2022-01-10 v1.6.0](https://github.com/mateusjunges/laravel-kafka/compare/v1.5.3...v1.6.0)
 ### Added
 - Add support for `ext-rdkafka` v6.0

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -7,6 +7,9 @@ use Junges\Kafka\Contracts\Consumer;
 
 class Config
 {
+    const SASL_PLAINTEXT = 'SASL_PLAINTEXT';
+    const SASL_SSL = 'SASL_SSL';
+
     public function __construct(
         private string $broker,
         private array $topics,
@@ -105,7 +108,7 @@ class Config
 
     private function usingSasl(): bool
     {
-        return strtoupper($this->securityProtocol) === 'SASL_PLAINTEXT'
-            || strtoupper($this->securityProtocol) === 'SASL_SSL';
+        return strtoupper($this->securityProtocol) === static::SASL_PLAINTEXT
+            || strtoupper($this->securityProtocol) === static::SASL_SSL;
     }
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -105,6 +105,7 @@ class Config
 
     private function usingSasl(): bool
     {
-        return $this->securityProtocol === 'SASL_PLAINTEXT' || $this->securityProtocol === 'SASL_SSL';
+        return strtoupper($this->securityProtocol) === 'SASL_PLAINTEXT'
+            || strtoupper($this->securityProtocol) === 'SASL_SSL';
     }
 }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -177,4 +177,38 @@ class ConfigTest extends LaravelKafkaTestCase
             $config->getProducerOptions()
         );
     }
+
+    public function testSaslCanBeUsedWithLowercaseConfigKeys()
+    {
+        $config = new Config(
+            broker: 'broker',
+            topics: ['topic'],
+            securityProtocol: 'sasl_plaintext',
+            commit: 1,
+            groupId: 'group',
+            consumer: $this->createMock(Consumer::class),
+            sasl: new Sasl(
+                username: 'username',
+                password: 'password',
+                mechanisms: 'mechanisms',
+                securityProtocol: 'ssl_plaintext',
+            ),
+            dlq: null
+        );
+
+        $expectedOptions = [
+            'compression.codec' => 'snappy',
+            'bootstrap.servers' => 'broker',
+            'metadata.broker.list' => 'broker',
+            'security.protocol' => 'ssl_plaintext',
+            'sasl.mechanisms' => 'mechanisms',
+            'sasl.username' => 'username',
+            'sasl.password' => 'password',
+        ];
+
+        $this->assertEquals(
+            $expectedOptions,
+            $config->getProducerOptions()
+        );
+    }
 }


### PR DESCRIPTION
This PR fixes #69, allowing to use SASL with lower and uppercase config keys.