### PR TITLE
Remove producer config property from `getConsumerOptions` method

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -67,7 +67,6 @@ class Config
             'metadata.broker.list' => $this->broker,
             'auto.offset.reset' => config('kafka.offset_reset', 'latest'),
             'enable.auto.commit' => config('kafka.auto_commit', true) === true ? 'true' : 'false',
-            'compression.codec' => config('kafka.compression', 'snappy'),
             'group.id' => $this->groupId,
             'bootstrap.servers' => $this->broker,
         ];

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -9,6 +9,55 @@ class Config
 {
     const SASL_PLAINTEXT = 'SASL_PLAINTEXT';
     const SASL_SSL = 'SASL_SSL';
+    const PRODUCER_ONLY_CONFIG_OPTIONS = [
+        'transactional.id',
+        'transaction.timeout.ms',
+        'enable.idempotence',
+        'enable.gapless.guarantee',
+        'queue.buffering.max.messages',
+        'queue.buffering.max.kbytes',
+        'queue.buffering.max.ms',
+        'linger.ms',
+        'message.send.max.retries',
+        'retries',
+        'retry.backoff.ms',
+        'queue.buffering.backpressure.threshold',
+        'compression.codec',
+        'compression.type',
+        'batch.num.messages',
+        'batch.size',
+        'delivery.report.only.error',
+        'dr_cb',
+        'dr_msg_cb',
+        'sticky.partitioning.linger.ms'
+    ];
+    const CONSUMER_ONLY_CONFIG_OPTIONS = [
+        'partition.assignment.strategy',
+        'session.timeout.ms',
+        'heartbeat.interval.ms',
+        'group.protocol.type',
+        'coordinator.query.interval.ms',
+        'max.poll.interval.ms',
+        'enable.auto.commit',
+        'auto.commit.interval.ms',
+        'enable.auto.offset.store',
+        'queued.min.messages',
+        'queued.max.messages.kbytes',
+        'fetch.wait.max.ms',
+        'fetch.message.max.bytes',
+        'max.partition.fetch.bytes',
+        'fetch.max.bytes',
+        'fetch.min.bytes',
+        'fetch.error.backoff.ms',
+        'offset.store.method',
+        'isolation.level',
+        'consume_cb',
+        'rebalance_cb',
+        'offset_commit_cb',
+        'enable.partition.eof',
+        'check.crcs',
+        'allow.auto.create.topics'
+    ];
 
     public function __construct(
         private string $broker,
@@ -75,7 +124,9 @@ class Config
             $options['enable.auto.commit'] = $this->autoCommit === true ? 'true' : 'false';
         }
 
-        return array_merge($options, $this->customOptions, $this->getSaslOptions());
+        return collect(array_merge($options, $this->customOptions, $this->getSaslOptions()))
+            ->reject(fn ($option) => in_array($option, self::PRODUCER_ONLY_CONFIG_OPTIONS))
+            ->toArray();
     }
 
     #[Pure]
@@ -87,7 +138,9 @@ class Config
             'metadata.broker.list' => $this->broker,
         ];
 
-        return array_merge($config, $this->customOptions, $this->getSaslOptions());
+        return collect(array_merge($config, $this->customOptions, $this->getSaslOptions()))
+            ->reject(fn ($option) => in_array($option, self::CONSUMER_ONLY_CONFIG_OPTIONS))
+            ->toArray();
     }
 
     #[Pure]

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -25,7 +25,6 @@ class ConfigTest extends LaravelKafkaTestCase
         $expectedOptions = [
             'auto.offset.reset' => 'latest',
             'enable.auto.commit' => 'true',
-            'compression.codec' => 'snappy',
             'group.id' => 'group',
             'bootstrap.servers' => 'broker',
             'metadata.broker.list' => 'broker',


### PR DESCRIPTION
This PR removes the `compression.codec` configuration option from the consumer configuration. Fixes #75 