### PR TITLE
[v1.6.x] Fix sasl authentication

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -67,7 +67,6 @@ class Config
             'metadata.broker.list' => $this->broker,
             'auto.offset.reset' => config('kafka.offset_reset', 'latest'),
             'enable.auto.commit' => config('kafka.auto_commit', true) === true ? 'true' : 'false',
-            'compression.codec' => config('kafka.compression', 'snappy'),
             'group.id' => $this->groupId,
             'bootstrap.servers' => $this->broker,
         ];

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -279,7 +279,7 @@ class Consumer
         return app(KafkaConsumerMessage::class, [
             'topicName' => $message->topic_name,
             'partition' => $message->partition,
-            'headers' => $message->headers,
+            'headers' => $message->headers ?? [],
             'body' => $message->payload,
             'key' => $message->key,
             'offset' => $message->offset,

--- a/src/Producers/ProducerBuilder.php
+++ b/src/Producers/ProducerBuilder.php
@@ -157,6 +157,7 @@ class ProducerBuilder implements CanProduceMessages
         $conf = new Config(
             broker: $this->broker,
             topics: [$this->getTopic()],
+            securityProtocol: $this->saslConfig?->getSecurityProtocol(),
             sasl: $this->saslConfig,
             customOptions: $this->options,
         );


### PR DESCRIPTION
This PR passes the `securityProtocol` key to the config class when using sasl. Should fix #77 