### PR TITLE
[1.6.x] Add `auto.offset.reset` as consumer only config option

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -57,6 +57,7 @@ class Config
         'enable.partition.eof',
         'check.crcs',
         'allow.auto.create.topics',
+        'auto.offset.reset',
     ];
 
     public function __construct(


### PR DESCRIPTION
This PR adds the missing `auto.offset.reset` config options to the consumer only options array