### PR TITLE
[1.6.x] Use correct consumer group id config key

### DIFF
--- a/src/Console/Commands/KafkaConsumerCommand.php
+++ b/src/Console/Commands/KafkaConsumerCommand.php
@@ -29,7 +29,7 @@ class KafkaConsumerCommand extends Command
 
         $this->config = [
             'brokers' => config('kafka.brokers'),
-            'groupId' => config('kafka.group_id'),
+            'groupId' => config('kafka.consumer_group_id'),
             'securityProtocol' => config('kafka.securityProtocol'),
             'sasl' => [
                 'mechanisms' => config('kafka.sasl.mechanisms'),


### PR DESCRIPTION
This PR fixes #81 