### PR TITLE
[1.7.x] Fix serialize

### DIFF
--- a/src/Producers/Producer.php
+++ b/src/Producers/Producer.php
@@ -54,7 +54,7 @@ class Producer
         $topic = $this->producer->newTopic($this->topic);
 
         $message = clone $message;
-        
+
         $message = $this->serializer->serialize($message);
 
         $this->produceMessage($topic, $message);

--- a/src/Producers/Producer.php
+++ b/src/Producers/Producer.php
@@ -53,6 +53,8 @@ class Producer
     {
         $topic = $this->producer->newTopic($this->topic);
 
+        $message = clone $message;
+        
         $message = $this->serializer->serialize($message);
 
         $this->produceMessage($topic, $message);
@@ -75,6 +77,8 @@ class Producer
 
         $produced = 0;
         foreach ($messagesIterator as $message) {
+            $message = clone $message;
+            
             $message = $this->serializer->serialize($message);
 
             $this->produceMessage($topic, $message);

--- a/tests/LaravelKafkaTestCase.php
+++ b/tests/LaravelKafkaTestCase.php
@@ -11,6 +11,7 @@ use Orchestra\Testbench\TestCase as Orchestra;
 use RdKafka\KafkaConsumer;
 use RdKafka\Message;
 use RdKafka\Producer as KafkaProducer;
+use RdKafka\Conf;
 
 class LaravelKafkaTestCase extends Orchestra
 {
@@ -57,9 +58,24 @@ class LaravelKafkaTestCase extends Orchestra
         $this->app->bind(Producer::class, function () use ($mockedProducer) {
             return $mockedProducer->getMock();
         });
+        $this->mockKafkaProducer();
+    }
+
+    protected function mockKafkaProducer()
+    {
+        // We have to get a topic object as a valid response for the mock
+        // We stub out this code here to achieve that
+        $conf = new Conf();
+        $conf->set('log_level', 0);
+        $kafka = new KafkaProducer($conf);
+        $topic = $kafka->newTopic('test-topic');
 
         $mockedKafkaProducer = m::mock(KafkaProducer::class)
             ->shouldReceive('flush')
+            ->andReturn(RD_KAFKA_RESP_ERR_NO_ERROR)
+            ->shouldReceive('newTopic')
+            ->andReturn($topic)
+            ->shouldReceive('poll')
             ->andReturn(RD_KAFKA_RESP_ERR_NO_ERROR)
             ->getMock();
 

--- a/tests/Producers/ProducerTest.php
+++ b/tests/Producers/ProducerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Junges\Kafka\Tests\Producers;
+
+use Junges\Kafka\Config\Config;
+use Junges\Kafka\Message\Serializers\JsonSerializer;
+use Junges\Kafka\Producers\MessageBatch;
+use Junges\Kafka\Producers\Producer;
+use Junges\Kafka\Tests\LaravelKafkaTestCase;
+use Junges\Kafka\Message\Message;
+
+class ProducerTest extends LaravelKafkaTestCase
+{
+    public function test_it_does_not_double_serialize_a_message_when_using_json_serializer()
+    {
+        $this->mockKafkaProducer();
+        $producer = new Producer(new Config('broker', ['test-topic']), 'test-topic', new JsonSerializer());
+        $payload = ['key' => 'value'];
+
+        $message = new Message(
+            body: $payload,
+        );
+        $producer->produce($message);
+        $producer->produce($message);
+
+        $this->assertSame($payload, $message->getBody());
+    }
+
+    public function test_it_does_not_double_serialize_a_batch_message_when_using_json_serializer()
+    {
+        $this->mockKafkaProducer();
+        $producer = new Producer(new Config('broker', ['test-topic']), 'test-topic', new JsonSerializer());
+        $payload = ['key' => 'value'];
+
+        $message = new Message(
+            body: $payload,
+        );
+
+        $messageBatch = new MessageBatch();
+        $messageBatch->push($message);
+
+        $producer->produceBatch($messageBatch);
+        $producer->produceBatch($messageBatch);
+
+        $this->assertSame($payload, $message->getBody());
+    }
+}


### PR DESCRIPTION
Hi there 👋

Thanks for a great package!

When using the default serialize class in the changed file on the PR it actually edits the original variable therefore if you were to send the message twice (for whatever reason) it would serialize twice.. I've attached a screen grab of this happening in the kafka cluster.

You can replicate with the below

```php
use Junges\Kafka\Facades\Kafka;
use Junges\Kafka\Message\Message;

$message = new Message(
    body: ['key' => 'value'],
);

Kafka::publishOn('test-topic')->withMessage($message)->send();
Kafka::publishOn('test-topic')->withMessage($message)->send();
```

This PR simply clones the message - please let me know if you'd prefer a different approach
<img width="901" alt="Screenshot 2022-04-06 at 14 54 12" src="https://user-images.githubusercontent.com/26925537/161991495-8f5667f9-1455-434e-b8ba-a4be45daaf24.png">
