### PR TITLE
[v1.7.x] do not allow setting dlq without subscribing to topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All relevant changes to `mateusjunges/laravel-kafka` will be documented here.
 
+## [2022-04-19 v1.7.4](https://github.com/mateusjunges/laravel-kafka/compare/v1.7.3...v1.7.4)
+### Fixed
+- Fix undefined offset 0 when trying to set Dead Letter Queues without subscribing to any kafka topics ([#e06849c](https://github.com/mateusjunges/laravel-kafka/commit/e06849c13be412a42206b8931d1afc0d7d5ae155))
+
 ## [2022-04-19 v1.7.3](https://github.com/mateusjunges/laravel-kafka/compare/v1.7.2...v1.7.3)
 ### Fixed
 - Fixed Kafka Facade docblock on [#93](https://github.com/mateusjunges/laravel-kafka/pull/93) by @nmfzone

--- a/docs/consuming-messages/5-configuring-consumer-options.md
+++ b/docs/consuming-messages/5-configuring-consumer-options.md
@@ -13,10 +13,10 @@ To create a `dlq` in this package, you can use the `withDlq` method. If you don'
 adding the `-dlq` suffix to the topic name.
 
 ```php
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->withDlq();
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->subscribe('topic')->withDlq();
 
 //Or, specifying the dlq topic name:
-$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->withDlq('your-dlq-topic-name')
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()->subscribe('topic')->withDlq('your-dlq-topic-name')
 ```
 
 ### Using auto commit

--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -11,6 +11,7 @@ use Junges\Kafka\Config\NullBatchConfig;
 use Junges\Kafka\Config\Sasl;
 use Junges\Kafka\Contracts\HandlesBatchConfiguration;
 use Junges\Kafka\Contracts\MessageDeserializer;
+use Junges\Kafka\Exceptions\KafkaConsumerException;
 use Junges\Kafka\Support\Timer;
 
 class ConsumerBuilder
@@ -214,9 +215,14 @@ class ConsumerBuilder
      *
      * @param string|null $dlqTopic
      * @return $this
+     * @throws \Junges\Kafka\Exceptions\KafkaConsumerException
      */
     public function withDlq(?string $dlqTopic = null): self
     {
+        if (! isset($this->topics[0])) {
+            throw KafkaConsumerException::dlqCanNotBeSetWithoutSubscribingToAnyTopics();
+        }
+
         if (null === $dlqTopic) {
             $dlqTopic = $this->topics[0] . '-dlq';
         }

--- a/src/Exceptions/KafkaConsumerException.php
+++ b/src/Exceptions/KafkaConsumerException.php
@@ -4,4 +4,8 @@ namespace Junges\Kafka\Exceptions;
 
 class KafkaConsumerException extends LaravelKafkaException
 {
+    public static function dlqCanNotBeSetWithoutSubscribingToAnyTopics(): self
+    {
+        return new static("You must subscribe to a kafka topic before specifying the DLQ.");
+    }
 }

--- a/tests/Consumers/ConsumerBuilderTest.php
+++ b/tests/Consumers/ConsumerBuilderTest.php
@@ -11,6 +11,8 @@ use Junges\Kafka\Config\Config;
 use Junges\Kafka\Config\Sasl;
 use Junges\Kafka\Consumers\Consumer;
 use Junges\Kafka\Consumers\ConsumerBuilder;
+use Junges\Kafka\Exceptions\KafkaConsumerException;
+use Junges\Kafka\Facades\Kafka;
 use Junges\Kafka\Message\Deserializers\JsonDeserializer;
 use Junges\Kafka\Tests\Fakes\FakeConsumer;
 use Junges\Kafka\Tests\LaravelKafkaTestCase;
@@ -139,7 +141,7 @@ class ConsumerBuilderTest extends LaravelKafkaTestCase
 
     public function testItCanSetTheDeadLetterQueue()
     {
-        $consumer = ConsumerBuilder::create('broker')->withDlq('test-topic-dlq');
+        $consumer = ConsumerBuilder::create('broker')->subscribe('test')->withDlq('test-topic-dlq');
 
         $this->assertInstanceOf(Consumer::class, $consumer->build());
 
@@ -280,6 +282,13 @@ class ConsumerBuilderTest extends LaravelKafkaTestCase
 
         $committerFactory = $this->getPropertyWithReflection('committerFactory', $consumer);
         $this->assertInstanceOf($adhocCommitterFactory::class, $committerFactory);
+    }
+
+    public function testItCantCreateAConsumerWithDlqWithoutSubscribingToAnyTopics()
+    {
+        $this->expectException(KafkaConsumerException::class);
+
+        ConsumerBuilder::create('broker')->withDlq();
     }
 }
 


### PR DESCRIPTION
This PR fixes the undefined offset 0 error thrown when trying to set a DLQ without suscribing to any kafka topics.