### PR TITLE
[v1.7.x] Deprecation warning fix

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -3,14 +3,14 @@
 namespace Junges\Kafka\Config;
 
 use JetBrains\PhpStorm\Pure;
-use Junges\Kafka\Contracts\HandlesBatchConfiguration;
 use Junges\Kafka\Contracts\Consumer;
+use Junges\Kafka\Contracts\HandlesBatchConfiguration;
 
 class Config
 {
-    const SASL_PLAINTEXT = 'SASL_PLAINTEXT';
-    const SASL_SSL = 'SASL_SSL';
-    const PRODUCER_ONLY_CONFIG_OPTIONS = [
+    public const SASL_PLAINTEXT = 'SASL_PLAINTEXT';
+    public const SASL_SSL = 'SASL_SSL';
+    public const PRODUCER_ONLY_CONFIG_OPTIONS = [
         'transactional.id',
         'transaction.timeout.ms',
         'enable.idempotence',
@@ -32,7 +32,7 @@ class Config
         'dr_msg_cb',
         'sticky.partitioning.linger.ms',
     ];
-    const CONSUMER_ONLY_CONFIG_OPTIONS = [
+    public const CONSUMER_ONLY_CONFIG_OPTIONS = [
         'partition.assignment.strategy',
         'session.timeout.ms',
         'heartbeat.interval.ms',
@@ -171,7 +171,8 @@ class Config
 
     private function usingSasl(): bool
     {
-        return strtoupper($this->securityProtocol) === static::SASL_PLAINTEXT
-            || strtoupper($this->securityProtocol) === static::SASL_SSL;
+        return !is_null($this->securityProtocol) &&
+            (strtoupper($this->securityProtocol) === static::SASL_PLAINTEXT ||
+                strtoupper($this->securityProtocol) === static::SASL_SSL);
     }
 }


### PR DESCRIPTION
Hi there! Fixed annoying warning:
`[2022-05-18 10:04:38] laravel.WARNING: strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/vendor/mateusjunges/laravel-kafka/src/Config/Config.php on line 175`