### PR TITLE
[v1.7.x] Fix securityProtocol sasl config in consumer

### DIFF
--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -364,7 +364,7 @@ class ConsumerBuilder
         $config = new Config(
             broker: $this->brokers,
             topics: $this->topics,
-            securityProtocol: $this->securityProtocol,
+            securityProtocol: $this->getSecurityProtocol(),
             commit: $this->commit,
             groupId: $this->groupId,
             consumer: new CallableConsumer($this->handler, $this->middlewares),
@@ -393,6 +393,18 @@ class ConsumerBuilder
 
             throw new InvalidArgumentException("The topic name should be a string value. [{$type}] given.");
         }
+    }
+
+    /**
+     * Get security protocol depending if sasl is been set.
+     *
+     * @return string
+     */
+    private function getSecurityProtocol(): string
+    {
+        return $this->saslConfig !== null 
+            ? $this->saslConfig->getSecurityProtocol()
+            : $this->securityProtocol;
     }
 
     /**

--- a/tests/Consumers/ConsumerBuilderTest.php
+++ b/tests/Consumers/ConsumerBuilderTest.php
@@ -219,6 +219,27 @@ class ConsumerBuilderTest extends LaravelKafkaTestCase
         $this->assertEquals('security', $securityProtocol);
     }
 
+    public function testItCanSetSecurityProtocolViaSaslConfig()
+    {
+        $consumer = ConsumerBuilder::create('broker', ['foo'], 'group')
+            ->withSasl(
+                $sasl = new Sasl(
+                    'username',
+                    'password',
+                    'mechanisms',
+                    'protocol'
+                )
+            );
+
+        $consummerBuilt = $consumer->build();
+        $this->assertInstanceOf(Consumer::class, $consummerBuilt);
+
+        $consumerConfig = $this->getPropertyWithReflection('config', $consummerBuilt);
+        $securityProtocol = $this->getPropertyWithReflection('securityProtocol', $consumerConfig);
+        
+        $this->assertEquals('protocol', $securityProtocol);
+    }
+
     public function testItCanSetAutoCommit()
     {
         $consumer = ConsumerBuilder::create('broker')->withAutoCommit();


### PR DESCRIPTION
Hi, I'm testing the package with a Sasl connection and in the consumer builder, when the securityProtocol setting is specified, argument 4 of the Sasl class is not taken into account, so the only way to make it work is to use the withSecurityProtocol. method, this PR solves the problem