### PR TITLE
[v1.7.x] Fix docker file

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM mateusjunges/laravel:8.0-v1.5.3-5.0.0-8
+FROM mateusjunges/laravel:8.1-v1.8.0-5.0.2-8
 
 RUN apk add libzip-dev
 


### PR DESCRIPTION
The image `mateusjunges/laravel:8.0-v1.5.3-5.0.0-8` no longer exists