### PR TITLE
[v1.8.x] Better error handling when flush returns error

### DIFF
--- a/src/Exceptions/CouldNotPublishMessage.php
+++ b/src/Exceptions/CouldNotPublishMessage.php
@@ -11,4 +11,9 @@ class CouldNotPublishMessage extends LaravelKafkaException
     {
         return new static($message);
     }
+
+    public static function withMessage(string $message, int $code): self
+    {
+        return new static("Your message could not be published. Flush returned with error code $code: '$message'");
+    }
 }

--- a/src/Producers/Producer.php
+++ b/src/Producers/Producer.php
@@ -124,7 +124,9 @@ class Producer
                 return true;
             }
 
-            throw CouldNotPublishMessage::flushError();
+            $message = rd_kafka_err2str($result);
+
+            throw CouldNotPublishMessage::withMessage($message, $result);
         });
     }
 }

--- a/tests/KafkaTest.php
+++ b/tests/KafkaTest.php
@@ -241,7 +241,7 @@ class KafkaTest extends LaravelKafkaTestCase
     {
         $this->expectException(CouldNotPublishMessage::class);
 
-        $this->expectExceptionMessage("Sent messages may not be completed yet.");
+        $this->expectExceptionMessage("Your message could not be published. Flush returned with error code -196: 'Local: Communication failure with broker'");
 
         $mockedProducerTopic = m::mock(ProducerTopic::class)
             ->shouldReceive('producev')->once()


### PR DESCRIPTION
This PR improves the error handling when the call to `flush` method returns an error, giving context and error message.