### PR TITLE
[v1.8.x] Use dummy world instead of laravel namespace in dev classes

### DIFF
--- a/build/laravel-kernels/kernel.php
+++ b/build/laravel-kernels/kernel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console;
+namespace __LARAVEL_CONSOLE_NAMESPACE__;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;

--- a/build/test/Dockerfile
+++ b/build/test/Dockerfile
@@ -18,6 +18,8 @@ COPY tests /application/laravel-test/tests
 
 COPY build/laravel-kernels/kernel.php /application/laravel-test/app/Console/Kernel.php
 
+RUN sed -i 's/__LARAVEL_NAMESPACE__/App\\Console/g' /application/laravel-test/app/Console/Kernel.php
+
 COPY dev/kafka.php /application/laravel-test/config
 
 COPY src /application/laravel-kafka/src/

--- a/build/test/Dockerfile
+++ b/build/test/Dockerfile
@@ -16,7 +16,7 @@ COPY build/composer-files/composer.json-${LARAVEL_VERSION} /application/laravel-
 
 COPY tests /application/laravel-test/tests
 
-RUN sed -i 's/__LARAVEL_NAMESPACE__/App\\Console/g' /build/laravel-kernels/kernel.php
+RUN sed -i 's/__LARAVEL_CONSOLE_NAMESPACE__/App\\Console/g' /build/laravel-kernels/kernel.php
 
 COPY build/laravel-kernels/kernel.php /application/laravel-test/app/Console/Kernel.php
 

--- a/build/test/Dockerfile
+++ b/build/test/Dockerfile
@@ -16,9 +16,9 @@ COPY build/composer-files/composer.json-${LARAVEL_VERSION} /application/laravel-
 
 COPY tests /application/laravel-test/tests
 
-COPY build/laravel-kernels/kernel.php /application/laravel-test/app/Console/Kernel.php
+RUN sed -i 's/__LARAVEL_NAMESPACE__/App\\Console/g' /build/laravel-kernels/kernel.php
 
-RUN sed -i 's/__LARAVEL_NAMESPACE__/App\\Console/g' /application/laravel-test/app/Console/Kernel.php
+COPY build/laravel-kernels/kernel.php /application/laravel-test/app/Console/Kernel.php
 
 COPY dev/kafka.php /application/laravel-test/config
 

--- a/build/test/Dockerfile
+++ b/build/test/Dockerfile
@@ -16,9 +16,9 @@ COPY build/composer-files/composer.json-${LARAVEL_VERSION} /application/laravel-
 
 COPY tests /application/laravel-test/tests
 
-RUN sed -i 's/__LARAVEL_CONSOLE_NAMESPACE__/App\\Console/g' /build/laravel-kernels/kernel.php
-
 COPY build/laravel-kernels/kernel.php /application/laravel-test/app/Console/Kernel.php
+
+RUN sed -i 's/__LARAVEL_CONSOLE_NAMESPACE__/App\\Console/g' /application/laravel-test/app/Console/Kernel.php
 
 COPY dev/kafka.php /application/laravel-test/config
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -10,9 +10,9 @@ COPY dev/php.ini /usr/local/etc/php/conf.d
 
 COPY build/composer-files/composer.json-8 /application/laravel-test/composer.json
 
-RUN sed -i 's/__LARAVEL_CONSOLE_NAMESPACE__/App\\Console/g' /build/laravel-kernels/kernel.php
-
 COPY build/laravel-kernels/kernel.php /application/laravel-test/app/Console/Kernel.php
+
+RUN sed -i 's/__LARAVEL_CONSOLE_NAMESPACE__/App\\Console/g' /application/laravel-test/app/Console/Kernel.php
 
 COPY dev/kafka.php /application/laravel-test/config
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -10,9 +10,9 @@ COPY dev/php.ini /usr/local/etc/php/conf.d
 
 COPY build/composer-files/composer.json-8 /application/laravel-test/composer.json
 
-COPY build/laravel-kernels/kernel.php /application/laravel-test/app/Console/Kernel.php
+RUN sed -i 's/__LARAVEL_CONSOLE_NAMESPACE__/App\\Console/g' /build/laravel-kernels/kernel.php
 
-RUN sed -i 's/__LARAVEL_CONSOLE_NAMESPACE__/App\\Console/g' /application/laravel-test/app/Console/Kernel.php
+COPY build/laravel-kernels/kernel.php /application/laravel-test/app/Console/Kernel.php
 
 COPY dev/kafka.php /application/laravel-test/config
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -12,6 +12,8 @@ COPY build/composer-files/composer.json-8 /application/laravel-test/composer.jso
 
 COPY build/laravel-kernels/kernel.php /application/laravel-test/app/Console/Kernel.php
 
+RUN sed -i 's/__LARAVEL_CONSOLE_NAMESPACE__/App\\Console/g' /application/laravel-test/app/Console/Kernel.php
+
 COPY dev/kafka.php /application/laravel-test/config
 
 COPY composer.json /application/laravel-kafka/composer.json

--- a/dev/laravel-console-kernel.php
+++ b/dev/laravel-console-kernel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console;
+namespace __LARAVEL_CONSOLE_NAMESPACE__;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;


### PR DESCRIPTION
Fixes #126