### PR TITLE
Filter config options for consumer and producers

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -152,7 +152,7 @@ class Config
         ];
 
         return collect(array_merge($config, $this->customOptions, $this->getSaslOptions()))
-            ->reject(fn ($option) => in_array($option, self::CONSUMER_ONLY_CONFIG_OPTIONS))
+            ->reject(fn (string|int $option, string $key) => in_array($key, self::CONSUMER_ONLY_CONFIG_OPTIONS))
             ->toArray();
     }
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -139,7 +139,7 @@ class Config
         }
 
         return collect(array_merge($options, $this->customOptions, $this->getSaslOptions()))
-            ->reject(fn ($option) => in_array($option, self::PRODUCER_ONLY_CONFIG_OPTIONS))
+            ->reject(fn (string|int $option, string $key) => in_array($key, self::PRODUCER_ONLY_CONFIG_OPTIONS))
             ->toArray();
     }
 


### PR DESCRIPTION
This PR fixes the filter for producer and consumer only config options, avoiding the following logs:

```
%4|1667415046.254|CONFWARN|rdkafka#producer-2| [thrd:app]: Configuration property auto.offset.reset is a consumer property and will be ignored by this producer instance
```