### PR TITLE
Allow to configure sleep timeout on flush retry

### DIFF
--- a/config/kafka.php
+++ b/config/kafka.php
@@ -49,5 +49,10 @@ return [
      | Repository for batching messages together
      | Implement BatchRepositoryInterface to save batches in different storage
      */
-    'batch_repository' => env('KAFKA_BATCH_REPOSITORY', \Junges\Kafka\BatchRepositories\InMemoryBatchRepository::class),
+    'batch_repository' => env('KAFKA_BATCH_REPOSITORY', \Junges\Kafka\BatchRepositories\InMemoryBatchRepository::class),,
+
+    /*
+     | The sleep time in milliseconds that will be used when retrying flush
+     */
+    'flush_retry_sleep_in_ms' => 100,
 ];

--- a/src/Producers/Producer.php
+++ b/src/Producers/Producer.php
@@ -121,6 +121,8 @@ class Producer
      */
     private function flush(): mixed
     {
+        $sleepMilliseconds = config('kafka.flush_retry_sleep_in_ms', 100);
+
         return retry(10, function () {
             $result = $this->producer->flush(1000);
 
@@ -131,6 +133,6 @@ class Producer
             $message = rd_kafka_err2str($result);
 
             throw CouldNotPublishMessage::withMessage($message, $result);
-        });
+        }, $sleepMilliseconds);
     }
 }


### PR DESCRIPTION
This PR adds new config option `kafka.flush_retry_sleep_in_ms` that you can use to configure how much time the producer should sleep before retrying to flush.

fixes #155 