### PR TITLE
throw exceptions when consuming messages

### DIFF
--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -272,7 +272,7 @@ class Consumer implements CanConsumeMessages
                 $this->logger->error($message, $throwable, 'HANDLER_EXCEPTION');
             }
 
-            return false;
+            throw $throwable;
         }
     }
 


### PR DESCRIPTION
When consuming messages, if a custom exception is thrown, it just logs the error to the output and then `returns false`, since there might be some reporting methods available on the custom exception, this causes Laravel default exception handling not to work, so I just throw the exception so we can catch it in Laravel `Exceptions\Handler.php` and manually log/report it.