### PR TITLE
report the exception on consuming messages

### DIFF
--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -272,6 +272,8 @@ class Consumer implements CanConsumeMessages
                 $this->logger->error($message, $throwable, 'HANDLER_EXCEPTION');
             }
 
+            report($throwable);
+
             return false;
         }
     }


### PR DESCRIPTION
When consuming messages, if a custom exception is thrown, it just logs the error to the output and then `returns false`, since there might be some reporting methods available on the custom exception, this causes Laravel default exception handling not to work, so I just used `report()` helper on the exception.