### PR TITLE
Allow consumer to subscribe to signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All relevant changes to `mateusjunges/laravel-kafka` will be documented here.
 
+## [2023-02-09 v1.12.0](https://github.com/mateusjunges/laravel-kafka/compare/v1.11.0...v1.12.0)
+- Allow consumers to subscribe to `SIGQUIT` and `SIGTERM` signals by @mateusjunges on [#172](https://github.com/mateusjunges/laravel-kafka/pull/172)
+- Add `onStopConsume` method to the Consumer class
+
 ## [2023-01-30 v1.11.0](https://github.com/mateusjunges/laravel-kafka/compare/v1.10.2...v1.11.0)
 - Add support for Laravel 10 by @mateusjunges and @mihaileu on [#171](https://github.com/mateusjunges/laravel-kafka/pull/171)
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "monolog/monolog": "^2.3|^3.2",
         "flix-tech/avro-serde-php": "^1.7",
         "illuminate/support": "^9.0|^10.0",
-        "illuminate/contracts": "^9.0|^10.0"
+        "illuminate/contracts": "^9.0|^10.0",
+        "ext-pcntl": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
         "monolog/monolog": "^2.3|^3.2",
         "flix-tech/avro-serde-php": "^1.7",
         "illuminate/support": "^9.0|^10.0",
-        "illuminate/contracts": "^9.0|^10.0",
-        "ext-pcntl": "*"
+        "illuminate/contracts": "^9.0|^10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
@@ -47,5 +46,8 @@
                 "Junges\\Kafka\\Providers\\LaravelKafkaServiceProvider"
             ]
         }
+    },
+    "suggest": {
+        "ext-pcntl": "Required to enable all features of the kafka consumer"
     }
 }

--- a/docs/6-upgrade-guide.md
+++ b/docs/6-upgrade-guide.md
@@ -1,0 +1,37 @@
+---
+title: Upgrade Guide
+weight: 6
+---
+
+### Upgrading from `v1.11.x` to `v1.12.x`
+
+### High impact changes
+- Renamed method `stopConsume` to `stopConsuming`.
+- A new `onStopConsuming` method was added to the `\Junges\Kafka\Contracts\CanConsumeMessages` contract.
+- The former `stopConsume` method (now `stopConsuming`) doesn't accept a callback anymore. Instead, you must use the newly added `onStopConsuming` method to specify the callback that should run when the consumer stops consuming messages.
+
+```php
+// Laravel Kafka v1.11.x:
+$stoppableConsumer = Kafka::createConsumer(['topic'])
+    ->withConsumerGroupId('group')
+    ->withHandler(function ($message) use ($stoppableConsumer) {
+        // Handle the message
+        if ($shouldStopConsuming) {
+            $stoppableConsumer->stopConsume(function () {
+                // Run this callback when stop consuming
+            })
+        }
+    })
+    ->build();
+
+// In Laravel Kafka v1.12.x:
+$stoppableConsumer = Kafka::createConsumer(['topic'])
+    ->withConsumerGroupId('group')
+    ->withHandler(function ($message) use ($stoppableConsumer) {
+        // Handle the message
+    })
+    ->build()
+    ->onStopConsuming(function () {
+        // This will run when the consumer stops consuming messages.
+    })
+```

--- a/docs/advanced-usage/2-graceful-shutdown.md
+++ b/docs/advanced-usage/2-graceful-shutdown.md
@@ -8,7 +8,7 @@ Stopping consumers is very useful if you want to ensure you don't kill a process
 Starting from version `1.12.x` of this package, consumers automatically listen to the `SIGTERM` and `SIQUIT` signals, which means you can easily stop your consumers using those signals.
 
 ### Running callbacks when the consumer stops
-If your app requires that you run sum sort of processing when the consumers stop processing messages, you can use the `onStopConsume` method, available on the `\Junges\Kafka\Contracts\CanConsumeMessages` interface. This method accepts a `Closure` that will run once your consumer stops consuming. 
+If your app requires that you run sum sort of processing when the consumers stop processing messages, you can use the `onStopConsume` method, available on the `\Junges\Kafka\Contracts\CanConsumeMessages` interface. This method accepts a `Closure` that will run once your consumer stops consuming.
 
 ```php
 use Junges\Kafka\Facades\Kafka;
@@ -17,7 +17,7 @@ $consumer = Kafka::createConsumer(['topic'])
     ->withConsumerGroupId('group')
     ->withHandler(new Handler)
     ->build()
-    ->onStopConsume(static function () {
+    ->onStopConsuming(static function () {
         // Do something when the consumer stop consuming messages
     })
 

--- a/docs/advanced-usage/2-graceful-shutdown.md
+++ b/docs/advanced-usage/2-graceful-shutdown.md
@@ -5,26 +5,23 @@ weight: 2
 
 Stopping consumers is very useful if you want to ensure you don't kill a process halfway through processing a consumed message.
 
-To stop the consumer gracefully call the `stopConsume` method on a consumer instance.
+Starting from version `1.12.x` of this package, consumers automatically listen to the `SIGTERM` and `SIQUIT` signals, which means you can easily stop your consumers using those signals.
 
-This is particularly useful when using signal handlers.
+### Running callbacks when the consumer stops
+If your app requires that you run sum sort of processing when the consumers stop processing messages, you can use the `onStopConsume` method, available on the `\Junges\Kafka\Contracts\CanConsumeMessages` interface. This method accepts a `Closure` that will run once your consumer stops consuming. 
 
 ```php
-function gracefulShutdown(Consumer $consumer) {
-    $consumer->stopConsume(function() {
-        echo 'Stopped consuming';
-        exit(0);
-    });
-}
+use Junges\Kafka\Facades\Kafka;
 
 $consumer = Kafka::createConsumer(['topic'])
     ->withConsumerGroupId('group')
     ->withHandler(new Handler)
-    ->build();
-    
-pcntl_signal(SIGINT, fn() => gracefulShutdown($consumer));
+    ->build()
+    ->onStopConsume(static function () {
+        // Do something when the consumer stop consuming messages
+    })
 
 $consumer->consume();
 ```
 
-> You will require the [Process Control Extension](https://www.php.net/manual/en/book.pcntl.php) to be installed to utilise the `pcntl` methods.
+> You will require the [Process Control Extension](https://www.php.net/manual/en/book.pcntl.php) to be installed to utilise this feature.

--- a/docs/consuming-messages/4-message-handlers.md
+++ b/docs/consuming-messages/4-message-handlers.md
@@ -15,7 +15,7 @@ $consumer->withHandler(function(\Junges\Kafka\Contracts\KafkaConsumerMessage $me
 });
 ```
 
-Or, using a invokable class:
+Or, using an invokable class:
 
 ```php
 class Handler

--- a/src/Consumers/CallableConsumer.php
+++ b/src/Consumers/CallableConsumer.php
@@ -13,7 +13,7 @@ class CallableConsumer extends Consumer
 
     public function __construct(callable $handler, array $middlewares)
     {
-        $this->handler = Closure::fromCallable($handler);
+        $this->handler = $handler(...);
 
         $this->middlewares = array_map([$this, 'wrapMiddleware'], $middlewares);
         $this->middlewares[] = $this->wrapMiddleware(

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -85,9 +85,9 @@ class Consumer implements CanConsumeMessages
         $this->cancelStopConsume();
         $this->configureRestartTimer();
 
-	if ($this->supportAsyncSignals()) {
-		$this->listenForSignals();
-	}
+        if ($this->supportAsyncSignals()) {
+            $this->listenForSignals();
+        }
 
         $this->consumer = app(KafkaConsumer::class, [
             'conf' => $this->setConf($this->config->getConsumerOptions()),

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -106,7 +106,8 @@ class Consumer implements CanConsumeMessages
         } while (! $this->maxMessagesLimitReached() && ! $this->stopRequested);
 
         if ($this->shouldRunStopConsumingCallback()) {
-            Closure::fromCallable($this->whenStopConsuming)();
+            $callback = $this->whenStopConsuming;
+            $callback(...)();
         }
     }
 

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -115,18 +115,18 @@ class Consumer implements CanConsumeMessages
         }
     }
 
-	private function listenForSignals(): void
-	{
-		pcntl_async_signals(true);
+    private function listenForSignals(): void
+    {
+        pcntl_async_signals(true);
 
-		pcntl_signal(SIGQUIT, fn () => $this->stopRequested = true);
-		pcntl_signal(SIGTERM, fn () => $this->stopRequested = true);
-	}
+        pcntl_signal(SIGQUIT, fn () => $this->stopRequested = true);
+        pcntl_signal(SIGTERM, fn () => $this->stopRequested = true);
+    }
 
-	private function supportAsyncSignals(): bool
-	{
-		return extension_loaded('pcntl');
-	}
+    private function supportAsyncSignals(): bool
+    {
+        return extension_loaded('pcntl');
+    }
 
     /**
      * Requests the consumer to stop after it's finished processing any messages to allow graceful exit

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -56,7 +56,7 @@ class Consumer implements CanConsumeMessages
     private CommitterFactory $committerFactory;
     private MessageDeserializer $deserializer;
     private bool $stopRequested = false;
-    private ?Closure $onStopConsume = null;
+    private ?Closure $whenStopConsuming = null;
     protected int $lastRestart = 0;
     protected Timer $restartTimer;
 
@@ -105,8 +105,8 @@ class Consumer implements CanConsumeMessages
             $this->checkForRestart();
         } while (! $this->maxMessagesLimitReached() && ! $this->stopRequested);
 
-        if ($this->onStopConsume) {
-            Closure::fromCallable($this->onStopConsume)();
+        if ($this->whenStopConsuming) {
+            Closure::fromCallable($this->whenStopConsuming)();
         }
     }
 
@@ -124,15 +124,15 @@ class Consumer implements CanConsumeMessages
     }
 
     /** @inheritdoc  */
-    public function stopConsume(): void
+    public function stopConsuming(): void
     {
         $this->stopRequested = true;
     }
 
     /** @inheritdoc  */
-    public function onStopConsume(?Closure $onStopConsume = null): self
+    public function onStopConsuming(?Closure $onStopConsuming = null): self
     {
-        $this->onStopConsume = $onStopConsume;
+        $this->whenStopConsuming = $onStopConsuming;
 
         return $this;
     }
@@ -374,7 +374,7 @@ class Consumer implements CanConsumeMessages
         }
 
         if ($this->config->shouldStopAfterLastMessage() && in_array($message->err, self::CONSUME_STOP_EOF_ERRORS, true)) {
-            $this->stopConsume();
+            $this->stopConsuming();
         }
 
         if (! in_array($message->err, self::IGNORABLE_CONSUMER_ERRORS, true)) {

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -105,9 +105,14 @@ class Consumer implements CanConsumeMessages
             $this->checkForRestart();
         } while (! $this->maxMessagesLimitReached() && ! $this->stopRequested);
 
-        if ($this->whenStopConsuming) {
+        if ($this->shouldRunStopConsumingCallback()) {
             Closure::fromCallable($this->whenStopConsuming)();
         }
+    }
+
+    private function shouldRunStopConsumingCallback(): bool
+    {
+        return $this->whenStopConsuming !== null;
     }
 
     private function listenForSignals(): void

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -85,9 +85,9 @@ class Consumer implements CanConsumeMessages
         $this->cancelStopConsume();
         $this->configureRestartTimer();
 
-		if ($this->supportAsyncSignals()) {
-			$this->listenForSignals();
-		}
+	if ($this->supportAsyncSignals()) {
+		$this->listenForSignals();
+	}
 
         $this->consumer = app(KafkaConsumer::class, [
             'conf' => $this->setConf($this->config->getConsumerOptions()),

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -84,7 +84,10 @@ class Consumer implements CanConsumeMessages
     {
         $this->cancelStopConsume();
         $this->configureRestartTimer();
-		$this->listenForSignals();
+
+		if ($this->supportAsyncSignals()) {
+			$this->listenForSignals();
+		}
 
         $this->consumer = app(KafkaConsumer::class, [
             'conf' => $this->setConf($this->config->getConsumerOptions()),
@@ -115,8 +118,14 @@ class Consumer implements CanConsumeMessages
 	private function listenForSignals(): void
 	{
 		pcntl_async_signals(true);
+
 		pcntl_signal(SIGQUIT, fn () => $this->stopRequested = true);
 		pcntl_signal(SIGTERM, fn () => $this->stopRequested = true);
+	}
+
+	private function supportAsyncSignals(): bool
+	{
+		return extension_loaded('pcntl');
 	}
 
     /**

--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -139,7 +139,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
      */
     public function withHandler(callable $handler): self
     {
-        $this->handler = Closure::fromCallable($handler);
+        $this->handler = $handler(...);
 
         return $this;
     }

--- a/src/Contracts/CanConsumeMessages.php
+++ b/src/Contracts/CanConsumeMessages.php
@@ -14,7 +14,7 @@ interface CanConsumeMessages
     public function consume(): void;
 
     /** Requests the consumer to stop after it's finished processing any messages to allow graceful exit. */
-    public function stopConsume(): void;
+    public function stopConsuming(): void;
 
     /**
      * Will cancel the stopConsume request initiated by calling the stopConsume method
@@ -27,5 +27,5 @@ interface CanConsumeMessages
     public function consumedMessagesCount(): int;
 
     /** Defines a callable that will run when the consumer stops consuming messages. */
-    public function onStopConsume(?Closure $onStopConsume = null): self;
+    public function onStopConsuming(?Closure $onStopConsuming = null): self;
 }

--- a/src/Contracts/CanConsumeMessages.php
+++ b/src/Contracts/CanConsumeMessages.php
@@ -13,12 +13,8 @@ interface CanConsumeMessages
      */
     public function consume(): void;
 
-    /**
-     * Requests the consumer to stop after it's finished processing any messages to allow graceful exit
-     *
-     * @param Closure|null $onStop
-     */
-    public function stopConsume(?Closure $onStop = null): void;
+    /** Requests the consumer to stop after it's finished processing any messages to allow graceful exit. */
+    public function stopConsume(): void;
 
     /**
      * Will cancel the stopConsume request initiated by calling the stopConsume method
@@ -29,4 +25,7 @@ interface CanConsumeMessages
      * Count the number of messages consumed by this consumer
      */
     public function consumedMessagesCount(): int;
+
+    /** Defines a callable that will run when the consumer stops consuming messages. */
+    public function onStopConsume(?Closure $onStopConsume = null): self;
 }

--- a/src/Support/Testing/Fakes/ConsumerFake.php
+++ b/src/Support/Testing/Fakes/ConsumerFake.php
@@ -52,7 +52,7 @@ class ConsumerFake implements CanConsumeMessages
     }
 
     /** @inheritdoc */
-    public function stopConsume(): void
+    public function stopConsuming(): void
     {
         $this->stopRequested = true;
     }
@@ -105,9 +105,9 @@ class ConsumerFake implements CanConsumeMessages
     }
 
     /** @inheritdoc  */
-    public function onStopConsume(?Closure $onStopConsume = null): CanConsumeMessages
+    public function onStopConsuming(?Closure $onStopConsuming = null): CanConsumeMessages
     {
-        $this->onStopConsume = $onStopConsume;
+        $this->onStopConsume = $onStopConsuming;
 
         return $this;
     }

--- a/src/Support/Testing/Fakes/ConsumerFake.php
+++ b/src/Support/Testing/Fakes/ConsumerFake.php
@@ -24,8 +24,8 @@ class ConsumerFake implements CanConsumeMessages
      * @param \Closure|null $onStopConsume
      */
     public function __construct(
-        private Config $config,
-        private array $messages = [],
+        private readonly Config $config,
+        private readonly array $messages = [],
         private bool $stopRequested = false,
         private ?Closure $onStopConsume = null
     ) {
@@ -51,15 +51,10 @@ class ConsumerFake implements CanConsumeMessages
         }
     }
 
-    /**
-     * Requests the consumer to stop after it's finished processing any messages to allow graceful exit
-     *
-     * @param Closure|null $onStop
-     */
-    public function stopConsume(?Closure $onStop = null): void
+    /** @inheritdoc */
+    public function stopConsume(): void
     {
         $this->stopRequested = true;
-        $this->onStopConsume = $onStop;
     }
 
     /**
@@ -107,6 +102,14 @@ class ConsumerFake implements CanConsumeMessages
     private function shouldStopConsuming(): bool
     {
         return $this->maxMessagesLimitReached() || $this->stopRequested;
+    }
+
+    /** @inheritdoc  */
+    public function onStopConsume(?Closure $onStopConsume = null): CanConsumeMessages
+    {
+        $this->onStopConsume = $onStopConsume;
+
+        return $this;
     }
 
     /**

--- a/tests/Consumers/ConsumerTest.php
+++ b/tests/Consumers/ConsumerTest.php
@@ -144,10 +144,10 @@ class ConsumerTest extends LaravelKafkaTestCase
         $this->stoppableConsumer = Kafka::createConsumer(['test'])
             ->withHandler(function (KafkaConsumerMessage $message) {
                 if ($this->stoppableConsumer && $message->getKey() === 'key2') {
-                    $this->stoppableConsumer->onStopConsume(function () {
+                    $this->stoppableConsumer->onStopConsuming(function () {
                         $this->stoppedConsumerMessage = "Consumer stopped.";
                         $this->stoppableConsumerStopped = true;
-                    })->stopConsume();
+                    })->stopConsuming();
                 }
             })
             ->withAutoCommit()

--- a/tests/Handlers/RetryableHandlerTest.php
+++ b/tests/Handlers/RetryableHandlerTest.php
@@ -16,7 +16,7 @@ class RetryableHandlerTest extends TestCase
     public function testItPassesWhenNoExceptionOccurred(): void
     {
         $failingHandler = new FailingHandler(0, new RuntimeException('test'));
-        $handler = new RetryableHandler(Closure::fromCallable($failingHandler), new DefaultRetryStrategy(), new FakeSleeper());
+        $handler = new RetryableHandler($failingHandler(...), new DefaultRetryStrategy(), new FakeSleeper());
 
         $messageMock = $this->createMock(KafkaConsumerMessage::class);
         $handler($messageMock);
@@ -28,7 +28,7 @@ class RetryableHandlerTest extends TestCase
     {
         $failingHandler = new FailingHandler(4, new RuntimeException('test'));
         $sleeper = new FakeSleeper();
-        $handler = new RetryableHandler(Closure::fromCallable($failingHandler), new DefaultRetryStrategy(), $sleeper);
+        $handler = new RetryableHandler($failingHandler(...), new DefaultRetryStrategy(), $sleeper);
 
         $messageMock = $this->createMock(KafkaConsumerMessage::class);
         $handler($messageMock);
@@ -41,7 +41,7 @@ class RetryableHandlerTest extends TestCase
     {
         $failingHandler = new FailingHandler(100, new RuntimeException('test'));
         $sleeper = new FakeSleeper();
-        $handler = new RetryableHandler(Closure::fromCallable($failingHandler), new DefaultRetryStrategy(), $sleeper);
+        $handler = new RetryableHandler($failingHandler(...), new DefaultRetryStrategy(), $sleeper);
 
         $messageMock = $this->createMock(KafkaConsumerMessage::class);
 

--- a/tests/KafkaFakeTest.php
+++ b/tests/KafkaFakeTest.php
@@ -26,14 +26,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->fake = new KafkaFake();
     }
 
-    public function testItReturnsAKafkaFakeInstance()
-    {
-        $kafka = Kafka::fake();
-
-        $this->assertInstanceOf(KafkaFake::class, $kafka);
-    }
-
-    public function testItStorePublishedMessagesOnArray()
+    public function testItStorePublishedMessagesOnArray(): void
     {
         $producer = $this->fake->publishOn('topic')
             ->withBodyKey('test', ['test'])
@@ -45,7 +38,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->fake->assertPublished($producer->getMessage());
     }
 
-    public function testAssertPublished()
+    public function testAssertPublished(): void
     {
         try {
             $this->fake->assertPublished(new Message('foo'));
@@ -62,7 +55,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->fake->assertPublished($producer->getMessage());
     }
 
-    public function testAssertPublishedTimes()
+    public function testAssertPublishedTimes(): void
     {
         try {
             $this->fake->assertPublished(new Message('foo'));
@@ -90,7 +83,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         }
     }
 
-    public function testItCanPerformAssertionsOnPublishedMessages()
+    public function testItCanPerformAssertionsOnPublishedMessages(): void
     {
         $producer = $this->fake->publishOn('topic')
             ->withBodyKey('test', ['test'])
@@ -119,7 +112,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         }
     }
 
-    public function testAssertPublishedOn()
+    public function testAssertPublishedOn(): void
     {
         $producer = $this->fake->publishOn('topic')
             ->withBodyKey('test', ['test'])
@@ -139,7 +132,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         }
     }
 
-    public function testAssertPublishedOnTimes()
+    public function testAssertPublishedOnTimes(): void
     {
         $producer = $this->fake->publishOn('topic')
             ->withBodyKey('test', ['test'])
@@ -159,7 +152,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         }
     }
 
-    public function testICanPerformAssertionsUsingAssertPublishedOn()
+    public function testICanPerformAssertionsUsingAssertPublishedOn(): void
     {
         $producer = $this->fake->publishOn('topic')
             ->withBodyKey('test', ['test'])
@@ -185,7 +178,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         });
     }
 
-    public function testNothingPublished()
+    public function testNothingPublished(): void
     {
         $this->fake->assertNothingPublished();
 
@@ -198,7 +191,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         }
     }
 
-    public function testPublishMessageBatch()
+    public function testPublishMessageBatch(): void
     {
         $messageBatch = new MessageBatch();
         $messageBatch->push(new Message());
@@ -213,7 +206,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->assertEquals(3, $producer->sendBatch($messageBatch));
     }
 
-    public function testFakeConsumer()
+    public function testFakeConsumer(): void
     {
         Kafka::fake();
 
@@ -240,7 +233,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $consumer->consume();
     }
 
-    public function testFakeConsumerWithSingleMultipleMessages()
+    public function testFakeConsumerWithSingleMultipleMessages(): void
     {
         Kafka::fake();
 
@@ -281,7 +274,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->assertEquals(count($messages), $consumer->consumedMessagesCount());
     }
 
-    public function testAReceivedMessageDoesItsJob()
+    public function testAReceivedMessageDoesItsJob(): void
     {
         Kafka::fake();
 
@@ -328,7 +321,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->assertEquals('1998-08-11 04:30:00', $posts[1]['published_at']);
     }
 
-    public function testStopFakeConsumer()
+    public function testStopFakeConsumer(): void
     {
         Kafka::fake();
 
@@ -359,11 +352,12 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->consumer = Kafka::createConsumer(['test-topic'])
             ->withHandler(function (KafkaConsumerMessage $message) use (&$stopped) {
                 //stop consumer after first message
-                $this->consumer->stopConsume(function () use (&$stopped) {
-                    $stopped = true;
-                });
+                $this->consumer->stopConsume();
             })
-            ->build();
+            ->build()
+            ->onStopConsume(function () use (&$stopped) {
+                $stopped = true;
+            });
 
         $this->consumer->consume();
         //testing stop callback
@@ -372,7 +366,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->assertEquals(1, $this->consumer->consumedMessagesCount());
     }
 
-    public function testFakeBatchConsumer()
+    public function testFakeBatchConsumer(): void
     {
         Kafka::fake();
 
@@ -413,7 +407,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->assertEquals(count($messages), $consumer->consumedMessagesCount());
     }
 
-    public function testFakeMultipleBatchConsumer()
+    public function testFakeMultipleBatchConsumer(): void
     {
         Kafka::fake();
 
@@ -498,7 +492,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->assertEquals(count($messages), $consumer->consumedMessagesCount());
     }
 
-    public function testStopFakeBatchConsumer()
+    public function testStopFakeBatchConsumer(): void
     {
         Kafka::fake();
 
@@ -540,9 +534,9 @@ class KafkaFakeTest extends LaravelKafkaTestCase
             ->withBatchSizeLimit(2)
             ->withHandler(function (Collection $messages) use (&$stopped) {
                 //stop consumer after first batch
-                $this->consumer->stopConsume(function () use (&$stopped) {
+                $this->consumer->onStopConsume(function () use (&$stopped) {
                     $stopped = true;
-                });
+                })->stopConsume();
             })
             ->build();
 

--- a/tests/KafkaFakeTest.php
+++ b/tests/KafkaFakeTest.php
@@ -352,10 +352,10 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->consumer = Kafka::createConsumer(['test-topic'])
             ->withHandler(function (KafkaConsumerMessage $message) use (&$stopped) {
                 //stop consumer after first message
-                $this->consumer->stopConsume();
+                $this->consumer->stopConsuming();
             })
             ->build()
-            ->onStopConsume(function () use (&$stopped) {
+            ->onStopConsuming(function () use (&$stopped) {
                 $stopped = true;
             });
 
@@ -534,9 +534,9 @@ class KafkaFakeTest extends LaravelKafkaTestCase
             ->withBatchSizeLimit(2)
             ->withHandler(function (Collection $messages) use (&$stopped) {
                 //stop consumer after first batch
-                $this->consumer->onStopConsume(function () use (&$stopped) {
+                $this->consumer->onStopConsuming(function () use (&$stopped) {
                     $stopped = true;
-                })->stopConsume();
+                })->stopConsuming();
             })
             ->build();
 

--- a/tests/LaravelKafkaTestCase.php
+++ b/tests/LaravelKafkaTestCase.php
@@ -24,7 +24,7 @@ class LaravelKafkaTestCase extends Orchestra
         app()->instance(Logger::class, $this->getMockedLogger());
     }
 
-    public function getEnvironmentSetUp($app)
+    public function getEnvironmentSetUp($app): void
     {
         $app['config']->set('kafka.brokers', 'localhost:9092');
         $app['config']->set('kafka.consumer_group_id', 'group');
@@ -43,7 +43,7 @@ class LaravelKafkaTestCase extends Orchestra
         ];
     }
 
-    protected function mockProducer()
+    protected function mockProducer(): void
     {
         $mockedProducer = m::mock(Producer::class)
             ->shouldReceive('withKey')
@@ -62,7 +62,7 @@ class LaravelKafkaTestCase extends Orchestra
         $this->mockKafkaProducer();
     }
 
-    protected function mockKafkaProducer()
+    protected function mockKafkaProducer(): void
     {
         // We have to get a topic object as a valid response for the mock
         // We stub out this code here to achieve that
@@ -85,7 +85,7 @@ class LaravelKafkaTestCase extends Orchestra
         });
     }
 
-    protected function mockConsumerWithMessageFailingCommit(Message $message)
+    protected function mockConsumerWithMessageFailingCommit(Message $message): void
     {
         $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
             ->shouldReceive('subscribe')
@@ -102,7 +102,7 @@ class LaravelKafkaTestCase extends Orchestra
         });
     }
 
-    protected function mockConsumerWithMessage(Message ...$message)
+    protected function mockConsumerWithMessage(Message ...$message): void
     {
         $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
             ->shouldReceive('subscribe')
@@ -121,7 +121,7 @@ class LaravelKafkaTestCase extends Orchestra
         });
     }
 
-    protected function getPropertyWithReflection(string $property, object $object)
+    protected function getPropertyWithReflection(string $property, object $object): mixed
     {
         $reflection = new \ReflectionClass($object);
         $reflectionProperty = $reflection->getProperty($property);


### PR DESCRIPTION
This PR adds the ability to consumers to subscribe to `SIGQUIT` and `SIGTERM` singals, stopping the consumer whenever one of these signals are received. In order to use it, you must have the `pcnt` extension loaded in your environment.