### PR TITLE
[2.x] Allow to queue message handlers

### DIFF
--- a/docs/consuming-messages/10-queueable-handlers.md
+++ b/docs/consuming-messages/10-queueable-handlers.md
@@ -1,0 +1,26 @@
+---
+title: Queueable handlers
+weight: 10
+---
+
+Queueable handlers allow you to handle your kafka messages in a queue. This will put a job into the Laravel queue system for each message received by your Kafka consumer.
+
+This only requires you to implements the `Illuminate\Contracts\Queue\ShouldQueue` interface in your Handler.
+
+This is how a queueable handler looks like:
+
+```php
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Junges\Kafka\Contracts\Handler;
+use Junges\Kafka\Contracts\KafkaConsumerMessage;
+
+class Handler implements HandlerContract, ShouldQueue
+{
+    public function __invoke(KafkaConsumerMessage $message): void
+    {
+        // Handle the consumed message.
+    }
+}
+```
+
+After creating your handler class, you can use it just as a normal handler, and `laravel-kafka` will know how to handle it under the hoods 😄.

--- a/src/Concerns/HandleConsumedMessage.php
+++ b/src/Concerns/HandleConsumedMessage.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Junges\Kafka\Concerns;
+
+use Closure;
+use Junges\Kafka\Contracts\Handler;
+use Junges\Kafka\Contracts\KafkaConsumerMessage;
+
+/**
+ * @internal
+ * @mixin \Junges\Kafka\Concerns\PrepareMiddlewares
+ */
+trait HandleConsumedMessage
+{
+    private function handleConsumedMessage(KafkaConsumerMessage $message, Handler|Closure $handler, array $middlewares = []): void
+    {
+        $middlewares = array_map($this->wrapMiddleware(...), $middlewares);
+        $middlewares = array_reverse($middlewares);
+
+        foreach ($middlewares as $middleware) {
+            $handler = $middleware($handler);
+        }
+
+        $handler($message);
+    }
+}

--- a/src/Concerns/PrepareMiddlewares.php
+++ b/src/Concerns/PrepareMiddlewares.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Junges\Kafka\Concerns;
+
+use Junges\Kafka\Contracts\Middleware;
+
+/** @internal */
+trait PrepareMiddlewares
+{
+    /** Wrap the message with a given middleware. */
+    private function wrapMiddleware(Middleware|string|callable $middleware): callable
+    {
+        $middleware = match(true) {
+            is_string($middleware) && is_subclass_of($middleware, Middleware::class) => new $middleware(),
+            $middleware instanceof Middleware => $middleware,
+            is_callable($middleware) => $middleware,
+            default => throw new \LogicException('Invalid middleware.')
+        };
+
+        return static fn (callable $handler) => static fn ($message) => $middleware($message, $handler);
+    }
+}

--- a/src/Consumers/CallableConsumer.php
+++ b/src/Consumers/CallableConsumer.php
@@ -3,49 +3,75 @@
 namespace Junges\Kafka\Consumers;
 
 use Closure;
+use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\App;
+use Junges\Kafka\Concerns\HandleConsumedMessage;
+use Junges\Kafka\Concerns\PrepareMiddlewares;
 use Junges\Kafka\Contracts\Consumer;
+use Junges\Kafka\Contracts\Handler;
 use Junges\Kafka\Contracts\KafkaConsumerMessage;
 
 class CallableConsumer extends Consumer
 {
-    private Closure $handler;
-    private array $middlewares;
+    use PrepareMiddlewares;
+    use HandleConsumedMessage;
 
-    public function __construct(callable $handler, array $middlewares)
+    private Dispatcher $dispatcher;
+
+    public function __construct(private Closure|Handler $handler, private readonly array $middlewares)
     {
-        $this->handler = $handler(...);
+        $this->handler = $this->handler instanceof Handler
+            ? $handler
+            : $handler(...);
 
-        $this->middlewares = array_map([$this, 'wrapMiddleware'], $middlewares);
-        $this->middlewares[] = $this->wrapMiddleware(
-            fn ($message, callable $next) => $next($message)
-        );
+        $this->dispatcher = App::make(Dispatcher::class);
     }
 
-    /**
-     * Handle the received message.
-     *
-     * @param KafkaConsumerMessage $message
-     */
+    /** Handle the received message. */
     public function handle(KafkaConsumerMessage $message): void
     {
-        $middlewares = array_reverse($this->middlewares);
-        $handler = array_shift($middlewares)($this->handler);
-
-        foreach ($middlewares as $middleware) {
-            $handler = $middleware($handler);
+        // If the message handler should be queued, we will dispatch a job to handle this message.
+        // Otherwise, the message will be handled synchronously.
+        if ($this->shouldQueueHandler()) {
+            $this->queueHandler($this->handler, $message, $this->middlewares);
+            return;
         }
 
-        $handler($message);
+        $this->handleMessageSynchronously($message);
+    }
+
+    private function shouldQueueHandler(): bool
+    {
+        return $this->handler instanceof ShouldQueue;
+    }
+
+    private function handleMessageSynchronously(KafkaConsumerMessage $message): void
+    {
+       $this->handleConsumedMessage($message, $this->handler, $this->middlewares);
     }
 
     /**
-     * Wrap the message with a given middleware.
-     *
-     * @param callable $middleware
-     * @return callable
+     * This method dispatches a job to handle the consumed message. You can customize the connection and
+     * queue in which it will be dispatched using the onConnection and onQueue methods. If this
+     * methods doesn't exist in the handler class, we will use the default configuration accordingly to
+     * your queue.php config file.
      */
-    private function wrapMiddleware(callable $middleware): callable
+    private function queueHandler(Handler $handler, KafkaConsumerMessage $message, array $middlewares): void
     {
-        return fn (callable $handler) => fn ($message) => $middleware($message, $handler);
+        $connection = config('queue.default');
+        if (method_exists($handler, 'onConnection')) {
+            $connection = $handler->onConnection();
+        }
+
+        $queue = config("queue.$connection.queue", 'default');
+        if (method_exists($handler, 'onQueue')) {
+            $queue = $handler->onQueue();
+        }
+        $this->dispatcher->dispatch(
+            (new DispatchQueuedHandler($handler, $message, $middlewares))
+                ->onQueue($queue)
+                ->onConnection($connection)
+        );
     }
 }

--- a/src/Consumers/CallableConsumer.php
+++ b/src/Consumers/CallableConsumer.php
@@ -68,6 +68,7 @@ class CallableConsumer extends Consumer
         if (method_exists($handler, 'onQueue')) {
             $queue = $handler->onQueue();
         }
+
         $this->dispatcher->dispatch(
             (new DispatchQueuedHandler($handler, $message, $middlewares))
                 ->onQueue($queue)

--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -72,9 +72,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         $this->deserializer = resolve(MessageDeserializer::class);
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public static function create(string $brokers, array $topics = [], string $groupId = null): self
     {
         return new ConsumerBuilder(
@@ -84,9 +82,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         );
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function subscribe(...$topics): self
     {
         if (is_array($topics[0])) {
@@ -104,9 +100,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withBrokers(?string $brokers): self
     {
         $this->brokers = $brokers ?? config('kafka.brokers');
@@ -114,9 +108,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withConsumerGroupId(?string $groupId): self
     {
         $this->groupId = $groupId;
@@ -124,9 +116,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withCommitBatchSize(int $size): self
     {
         $this->commit = $size;
@@ -134,9 +124,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withHandler(callable $handler): self
     {
         $this->handler = $handler(...);
@@ -144,9 +132,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function usingDeserializer(MessageDeserializer $deserializer): self
     {
         $this->deserializer = $deserializer;
@@ -154,9 +140,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function usingCommitterFactory(CommitterFactory $committerFactory): self
     {
         $this->committerFactory = $committerFactory;
@@ -164,9 +148,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withMaxMessages(int $maxMessages): self
     {
         $this->maxMessages = $maxMessages;
@@ -174,9 +156,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withMaxCommitRetries(int $maxCommitRetries): self
     {
         $this->maxCommitRetries = $maxCommitRetries;
@@ -184,9 +164,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withDlq(?string $dlqTopic = null): self
     {
         if (! isset($this->topics[0])) {
@@ -202,9 +180,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withSasl(Sasl $saslConfig): self
     {
         $this->saslConfig = $saslConfig;
@@ -212,9 +188,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withMiddleware(callable $middleware): self
     {
         $this->middlewares[] = $middleware;
@@ -222,9 +196,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withSecurityProtocol(string $securityProtocol): self
     {
         $this->securityProtocol = $securityProtocol;
@@ -232,9 +204,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withAutoCommit(bool $autoCommit = true): self
     {
         $this->autoCommit = $autoCommit;
@@ -242,9 +212,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withOptions(array $options): self
     {
         foreach ($options as $name => $value) {
@@ -254,9 +222,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withOption(string $name, mixed $value): self
     {
         $this->options[$name] = $value;
@@ -264,9 +230,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function enableBatching(): self
     {
         $this->batchingEnabled = true;
@@ -274,9 +238,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withBatchSizeLimit(int $batchSizeLimit): self
     {
         $this->batchSizeLimit = $batchSizeLimit;
@@ -284,9 +246,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function withBatchReleaseInterval(int $batchReleaseIntervalInMilliseconds): self
     {
         $this->batchReleaseInterval = $batchReleaseIntervalInMilliseconds;
@@ -294,9 +254,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function stopAfterLastMessage(bool $stopAfterLastMessage = true): self
     {
         $this->stopAfterLastMessage = $stopAfterLastMessage;
@@ -304,9 +262,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public function build(): CanConsumeMessages
     {
         $config = new Config(

--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -12,8 +12,10 @@ use Junges\Kafka\Config\NullBatchConfig;
 use Junges\Kafka\Config\Sasl;
 use Junges\Kafka\Contracts\CanConsumeMessages;
 use Junges\Kafka\Contracts\ConsumerBuilder as ConsumerBuilderContract;
+use Junges\Kafka\Contracts\Handler;
 use Junges\Kafka\Contracts\HandlesBatchConfiguration;
 use Junges\Kafka\Contracts\MessageDeserializer;
+use Junges\Kafka\Contracts\Middleware;
 use Junges\Kafka\Exceptions\KafkaConsumerException;
 use Junges\Kafka\Support\Timer;
 
@@ -24,7 +26,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
     protected array $topics;
     protected int $commit;
     protected ?string $groupId;
-    protected Closure $handler;
+    protected Closure | Handler $handler;
     protected int $maxMessages;
     protected int $maxCommitRetries;
     protected string $brokers;
@@ -125,9 +127,11 @@ class ConsumerBuilder implements ConsumerBuilderContract
     }
 
     /** @inheritDoc */
-    public function withHandler(callable $handler): self
+    public function withHandler(callable|Handler $handler): self
     {
-        $this->handler = $handler(...);
+        $this->handler = $handler instanceof Handler
+            ? $handler
+            : $handler(...);
 
         return $this;
     }
@@ -189,7 +193,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
     }
 
     /** @inheritDoc */
-    public function withMiddleware(callable $middleware): self
+    public function withMiddleware(Middleware|callable|string $middleware): self
     {
         $this->middlewares[] = $middleware;
 

--- a/src/Consumers/DispatchQueuedHandler.php
+++ b/src/Consumers/DispatchQueuedHandler.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Junges\Kafka\Consumers;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Junges\Kafka\Concerns\HandleConsumedMessage;
+use Junges\Kafka\Concerns\PrepareMiddlewares;
+use Junges\Kafka\Contracts\Handler;
+use Junges\Kafka\Contracts\KafkaConsumerMessage;
+
+final class DispatchQueuedHandler implements ShouldQueue
+{
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+    use PrepareMiddlewares;
+    use HandleConsumedMessage;
+
+    public function __construct(
+        public readonly Handler $handler,
+        public readonly KafkaConsumerMessage $message,
+        public readonly array $middlewares = []
+    ) {}
+
+    public function handle(): void
+    {
+        $this->handleConsumedMessage($this->message, $this->handler, $this->middlewares);
+    }
+}

--- a/src/Contracts/Handler.php
+++ b/src/Contracts/Handler.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Junges\Kafka\Contracts;
+
+interface Handler
+{
+    public function __invoke(KafkaConsumerMessage $message): void;
+}

--- a/src/Contracts/Middleware.php
+++ b/src/Contracts/Middleware.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Junges\Kafka\Contracts;
+
+interface Middleware {
+    public function __invoke(KafkaConsumerMessage $message, callable $next);
+}

--- a/src/Contracts/Middleware.php
+++ b/src/Contracts/Middleware.php
@@ -2,6 +2,7 @@
 
 namespace Junges\Kafka\Contracts;
 
-interface Middleware {
+interface Middleware
+{
     public function __invoke(KafkaConsumerMessage $message, callable $next);
 }

--- a/src/Support/Testing/Fakes/ConsumerBuilderFake.php
+++ b/src/Support/Testing/Fakes/ConsumerBuilderFake.php
@@ -18,9 +18,7 @@ class ConsumerBuilderFake extends ConsumerBuilder implements ConsumerBuilderCont
     /** @var \Junges\Kafka\Contracts\KafkaConsumerMessage[] */
     private array $messages = [];
 
-    /**
-     * @inheritDoc
-     */
+    /** @inheritDoc */
     public static function create(string $brokers, array $topics = [], string $groupId = null): self
     {
         return new ConsumerBuilderFake(

--- a/tests/Consumers/CallableConsumerTest.php
+++ b/tests/Consumers/CallableConsumerTest.php
@@ -24,7 +24,7 @@ class CallableConsumerTest extends LaravelKafkaTestCase
         $message->headers = [];
         $message->offset = 0;
 
-        $consumer = new CallableConsumer([$this, 'handleMessage'], [
+        $consumer = new CallableConsumer($this->handleMessage(...), [
             function (KafkaConsumerMessage $message, callable $next): void {
                 $decoded = json_decode($message->getBody());
                 $next($decoded);

--- a/tests/Consumers/ConsumerTest.php
+++ b/tests/Consumers/ConsumerTest.php
@@ -2,11 +2,13 @@
 
 namespace Junges\Kafka\Tests\Consumers;
 
+use Illuminate\Support\Facades\Bus;
 use Junges\Kafka\Commit\Contracts\CommitterFactory;
 use Junges\Kafka\Commit\VoidCommitter;
 use Junges\Kafka\Config\Config;
 use Junges\Kafka\Consumers\CallableConsumer;
 use Junges\Kafka\Consumers\Consumer;
+use Junges\Kafka\Consumers\DispatchQueuedHandler;
 use Junges\Kafka\Contracts\CanConsumeMessages;
 use Junges\Kafka\Contracts\KafkaConsumerMessage;
 use Junges\Kafka\Exceptions\KafkaConsumerException;
@@ -84,6 +86,33 @@ class ConsumerTest extends LaravelKafkaTestCase
         $consumer->consume();
 
         $this->assertInstanceOf(ConsumedMessage::class, $fakeConsumer->getMessage());
+    }
+
+    public function testItCanConsumeMessagesWithQueueableHandlers(): void
+    {
+        Bus::fake();
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test';
+        $message->payload = '{"body": "message payload"}';
+        $message->headers = [];
+        $message->partition = 1;
+        $message->offset = 0;
+
+        $this->mockConsumerWithMessage($message);
+
+        $this->mockProducer();
+
+        $consumer = Kafka::createConsumer(['test'])
+            ->withHandler($fakeConsumer = new SimpleQueueableHandler())
+            ->withAutoCommit()
+            ->withMaxMessages(1)
+            ->build();
+
+        $consumer->consume();
+
+        Bus::assertDispatched(DispatchQueuedHandler::class);
     }
 
     public function testConsumeMessageWithError()

--- a/tests/Consumers/SimpleQueueableHandler.php
+++ b/tests/Consumers/SimpleQueueableHandler.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Junges\Kafka\Tests\Consumers;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Junges\Kafka\Contracts\Handler;
+use Junges\Kafka\Contracts\KafkaConsumerMessage;
+
+final class SimpleQueueableHandler implements Handler, ShouldQueue
+{
+    public function __invoke(KafkaConsumerMessage $message): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR adds the ability to delay the execution of your message handlers by dispatching a job to the queue.

## Creating a queueable handler
To create a queueable message handler, you just need to implement the `ShouldQueue` and the `\Junges\Kafka\Contracts\Handler\  interfaces:

```php
use Junges\Kafka\Contracts\Handler as HandlerContract;

class Handler implements HandlerContract, ShouldQueue
{
    public function __invoke(KafkaConsumerMessage $message): void
    {
        // Handle the consumed message.
    }
}
```























