### PR TITLE
Add the ability to change the cache driver

### DIFF
--- a/config/kafka.php
+++ b/config/kafka.php
@@ -55,4 +55,9 @@ return [
      | The sleep time in milliseconds that will be used when retrying flush
      */
     'flush_retry_sleep_in_ms' => 100,
+
+    /*
+     | The cache driver that will be used
+     */
+    'cache_driver' => env('KAFKA_CACHE_DRIVER', env('CACHE_DRIVER', 'file')),
 ];

--- a/dev/kafka.php
+++ b/dev/kafka.php
@@ -9,5 +9,6 @@ return [
         'username' => '',
         'password' => '',
         'mechanisms' => '',
-    ]
+    ],
+    'cache_driver' => 'file',
 ];

--- a/docs/3-installation-and-setup.md
+++ b/docs/3-installation-and-setup.md
@@ -73,5 +73,10 @@ return [
      | The sleep time in milliseconds that will be used when retrying flush
      */
     'flush_retry_sleep_in_ms' => 100,
+
+    /*
+     | The cache driver that will be used
+     */
+    'cache_driver' => env('KAFKA_CACHE_DRIVER', env('CACHE_DRIVER', 'file')),
 ];
 ```

--- a/src/Console/Commands/KafkaRestartConsumersCommand.php
+++ b/src/Console/Commands/KafkaRestartConsumersCommand.php
@@ -16,7 +16,7 @@ class KafkaRestartConsumersCommand extends Command
 
     public function handle()
     {
-        Cache::forever('laravel-kafka:consumer:restart', $this->currentTime());
+        Cache::driver(config('kafka.cache_driver'))->forever('laravel-kafka:consumer:restart', $this->currentTime());
         $this->info('Kafka consumers restart signal sent.');
     }
 }

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -425,6 +425,6 @@ class Consumer implements CanConsumeMessages
 
     protected function getLastRestart(): int
     {
-        return Cache::get('laravel-kafka:consumer:restart', 0);
+        return Cache::driver(config('kafka.cache_driver'))->get('laravel-kafka:consumer:restart', 0);
     }
 }

--- a/tests/LaravelKafkaTestCase.php
+++ b/tests/LaravelKafkaTestCase.php
@@ -34,6 +34,7 @@ class LaravelKafkaTestCase extends Orchestra
         $app['config']->set('kafka.partition', 0);
         $app['config']->set('kafka.compression', 'snappy');
         $app['config']->set('kafka.debug', false);
+        $app['config']->set('kafka.cache_driver', 'file');
     }
 
     protected function getPackageProviders($app): array


### PR DESCRIPTION
In case you don't want to use the same cache driver as the application.
I think the test "testItCanRestartConsumer()" cover the modification, let me know if it's not enough.