### PR TITLE
Update README.md to link to the 1.13 documentation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you think this package helped you in any way, you can sponsor me on GitHub!
 [![Sponsor Me](art/sponsor.png)](https://github.com/sponsors/mateusjunges)
 
 # Documentation
-You can [find the documentations for this package here](https://junges.dev/documentation/laravel-kafka/v1.8/1-introduction)
+You can [find the documentations for this package here](https://junges.dev/documentation/laravel-kafka/v1.13/1-introduction)
 
 # Testing
 Run `composer test` to test this package.


### PR DESCRIPTION
Hey, I updated the README file, so the documentation link is pointing to 1.13 documentation, instead of 1.8 one.