### PR TITLE
Fixed default securityProtocol config

### DIFF
--- a/config/kafka.php
+++ b/config/kafka.php
@@ -7,6 +7,20 @@ return [
     'brokers' => env('KAFKA_BROKERS', 'localhost:9092'),
 
     /*
+     | Default security protocol
+     */
+    'securityProtocol' =>  env('KAFKA_SECURITY_PROTOCOL', 'PLAINTEXT'),
+
+    /*
+     | Default sasl configuration 
+     */
+    'sasl' => [
+        'mechanisms' => env('KAFKA_MECHANISMS', 'PLAINTEXT'),
+        'username' => env('KAFKA_USERNAME', null),
+        'password' => env('KAFKA_PASSWORD', null)
+    ],
+
+    /*
      | Kafka consumers belonging to the same consumer group share a group id.
      | The consumers in a group then divides the topic partitions as fairly amongst themselves as possible by
      | establishing that each partition is only consumed by a single consumer from the group.

--- a/src/Console/Commands/KafkaConsumer/Options.php
+++ b/src/Console/Commands/KafkaConsumer/Options.php
@@ -87,9 +87,11 @@ class Options
 
     public function getSecurityProtocol(): ?string
     {
-        return (
-            strlen($this->securityProtocol) > 1 ? $this->securityProtocol : $this->config['securityProtocol']
-        ) || 'plaintext';
+        $securityProtocol = strlen($this->securityProtocol) > 1
+            ? $this->securityProtocol
+            : $this->config['securityProtocol'];
+
+        return $securityProtocol ?? 'plaintext';
     }
 
     public function getBroker()

--- a/src/Console/Commands/KafkaConsumer/Options.php
+++ b/src/Console/Commands/KafkaConsumer/Options.php
@@ -14,7 +14,7 @@ class Options
     private ?int $commit = 1;
     private ?string $dlq = null;
     private int $maxMessages = -1;
-    private ?string $securityProtocol = 'plaintext';
+    private ?string $securityProtocol = null;
     private ?string $saslUsername;
     private ?string $saslPassword;
     private ?string $saslMechanisms;
@@ -81,13 +81,13 @@ class Options
             username: $this->saslUsername,
             password: $this->saslPassword,
             mechanisms: $this->saslMechanisms,
-            securityProtocol: $this->securityProtocol
+            securityProtocol: $this->getSecurityProtocol()
         );
     }
 
     public function getSecurityProtocol(): ?string
     {
-        return $this->securityProtocol;
+        return strlen($this->securityProtocol) > 1 ? $this->securityProtocol : $this->config['securityProtocol'];
     }
 
     public function getBroker()

--- a/src/Console/Commands/KafkaConsumer/Options.php
+++ b/src/Console/Commands/KafkaConsumer/Options.php
@@ -87,7 +87,9 @@ class Options
 
     public function getSecurityProtocol(): ?string
     {
-        return strlen($this->securityProtocol) > 1 ? $this->securityProtocol : $this->config['securityProtocol'];
+        return (
+            strlen($this->securityProtocol) > 1 ? $this->securityProtocol : $this->config['securityProtocol']
+        ) || 'plaintext';
     }
 
     public function getBroker()

--- a/src/Console/Commands/KafkaConsumerCommand.php
+++ b/src/Console/Commands/KafkaConsumerCommand.php
@@ -53,10 +53,10 @@ class KafkaConsumerCommand extends Command
 
             return;
         }
-        
-        $options = new Options(array_map(function ($value) {
-            return $value === '?' ? null : $value;
-        }, $this->options()), $this->config);
+
+        $parsedOptions = array_map(fn ($value) => $value === '?' ? null : $value, $this->options());
+
+        $options = new Options($parsedOptions, $this->config);
 
         $consumer = $options->getConsumer();
         $deserializer = $options->getDeserializer();

--- a/src/Console/Commands/KafkaConsumerCommand.php
+++ b/src/Console/Commands/KafkaConsumerCommand.php
@@ -53,7 +53,10 @@ class KafkaConsumerCommand extends Command
 
             return;
         }
-        $options = new Options($this->options(), $this->config);
+        
+        $options = new Options(array_map(function ($value) {
+            return $value === '?' ? null : $value;
+        }, $this->options()), $this->config);
 
         $consumer = $options->getConsumer();
         $deserializer = $options->getDeserializer();


### PR DESCRIPTION
Hi @mateusjunges 

When runing:

```cli
php artisan kafka:consume --topics=my-topic --consumer="\\App\\Consumers\\MyConsumer"
```

I takes settings from `config`, but `securityProtocol` is ommited, so you have to explicity pass it `--securityProtocol=SASL_SSL`.

