### PR TITLE
Update CanConsumeMessages.php

### DIFF
--- a/src/Contracts/CanConsumeMessages.php
+++ b/src/Contracts/CanConsumeMessages.php
@@ -9,7 +9,7 @@ interface CanConsumeMessages
     /**
      * Consume messages from a kafka topic in loop.
      *
-     * @throws \RdKafka\Exception|\Carbon\Exceptions\Exception
+     * @throws \RdKafka\Exception|\Carbon\Exceptions\Exception|\Junges\Kafka\Exceptions\KafkaConsumerException
      */
     public function consume(): void;
 


### PR DESCRIPTION
fix: added \Junges\Kafka\Exceptions\KafkaConsumerException throwable to consume()