### PR TITLE
Make Kafka macroable

### DIFF
--- a/src/Kafka.php
+++ b/src/Kafka.php
@@ -2,6 +2,7 @@
 
 namespace Junges\Kafka;
 
+use Illuminate\Support\Traits\Macroable;
 use Junges\Kafka\Consumers\ConsumerBuilder;
 use Junges\Kafka\Contracts\CanConsumeMessagesFromKafka;
 use Junges\Kafka\Contracts\CanProduceMessages;
@@ -10,6 +11,8 @@ use Junges\Kafka\Producers\ProducerBuilder;
 
 class Kafka implements CanPublishMessagesToKafka, CanConsumeMessagesFromKafka
 {
+    use Macroable;
+
     /**
      * Creates a new ProducerBuilder instance, setting brokers and topic.
      *

--- a/tests/KafkaTest.php
+++ b/tests/KafkaTest.php
@@ -3,6 +3,7 @@
 namespace Junges\Kafka\Tests;
 
 use Illuminate\Support\Str;
+use Junges\Kafka\Config\Sasl;
 use Junges\Kafka\Consumers\ConsumerBuilder;
 use Junges\Kafka\Contracts\KafkaProducerMessage;
 use Junges\Kafka\Exceptions\CouldNotPublishMessage;
@@ -292,5 +293,19 @@ class KafkaTest extends LaravelKafkaTestCase
         });
 
         Kafka::publishOn('test')->withBodyKey('foo', 'bar')->sendBatch($messageBatch);
+    }
+
+    public function testMacro()
+    {
+        $sasl = new Sasl(username: 'username', password: 'password', mechanisms: 'mechanisms');
+
+        Kafka::macro('defaultProducer', function (string $topic) use ($sasl) {
+            return $this->publishOn($topic)->withSasl($sasl);
+        });
+
+        $producer = Kafka::defaultProducer('test-topic');
+
+        $this->assertInstanceOf(ProducerBuilder::class, $producer);
+        $this->assertEquals($sasl, $this->getPropertyWithReflection('saslConfig', $producer));
     }
 }


### PR DESCRIPTION
In order to make use of macros the Illuminate Macroable trait has been added to Junges\Kafka\Kafka.

An example could look like this:

```php
$sasl = new Sasl(username: 'username', password: 'password', mechanisms: 'mechanisms');

Kafka::macro('defaultProducer', function (string $topic) use ($sasl) {
    return $this->publishOn($topic)->withSasl($sasl);
});

$producer = Kafka::defaultProducer('test-topic');
```