### PR TITLE
Modifiable `client.id` 

### DIFF
--- a/config/kafka.php
+++ b/config/kafka.php
@@ -21,6 +21,11 @@ return [
     ],
 
     /*
+     | Client identifier
+     */
+    'client_id' => env('KAFKA_CLIENT_ID', 'laravel'),
+
+    /*
      | Kafka consumers belonging to the same consumer group share a group id.
      | The consumers in a group then divides the topic partitions as fairly amongst themselves as possible by
      | establishing that each partition is only consumed by a single consumer from the group.

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -69,6 +69,7 @@ class Config
         private array              $topics,
         private ?string            $securityProtocol = null,
         private ?int               $commit = null,
+        private ?string            clientId = null,
         private ?string            $groupId = null,
         private ?Consumer          $consumer = null,
         private ?Sasl              $sasl = null,
@@ -132,7 +133,7 @@ class Config
             'auto.offset.reset' => config('kafka.offset_reset', 'latest'),
             'enable.auto.commit' => config('kafka.auto_commit', true) === true ? 'true' : 'false',
             'group.id' => $this->groupId,
-            'client.id' => config('kafka.client_id'),
+            'client.id' => $this->clientId,
             'bootstrap.servers' => $this->broker,
         ];
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -59,6 +59,7 @@ class Config
         'check.crcs',
         'allow.auto.create.topics',
         'auto.offset.reset',
+        'client.id',
     ];
 
     private HandlesBatchConfiguration $batchConfig;
@@ -131,6 +132,7 @@ class Config
             'auto.offset.reset' => config('kafka.offset_reset', 'latest'),
             'enable.auto.commit' => config('kafka.auto_commit', true) === true ? 'true' : 'false',
             'group.id' => $this->groupId,
+            'client.id' => config('kafka.client_id'),
             'bootstrap.servers' => $this->broker,
         ];
 

--- a/src/Console/Commands/KafkaConsumer/Options.php
+++ b/src/Console/Commands/KafkaConsumer/Options.php
@@ -10,6 +10,7 @@ class Options
     private ?array $topics = null;
     private ?string $consumer = null;
     private ?string $deserializer = null;
+    private ?string $clientId = null;
     private ?string $groupId = null;
     private ?int $commit = 1;
     private ?string $dlq = null;
@@ -58,6 +59,11 @@ class Options
     public function getCommit(): ?string
     {
         return $this->commit;
+    }
+
+    public function getClientId(): ?string
+    {
+        return strlen($this->clientId) > 1 ? $this->clientId : $this->config['clientId'];
     }
 
     public function getDlq(): ?string

--- a/src/Console/Commands/KafkaConsumerCommand.php
+++ b/src/Console/Commands/KafkaConsumerCommand.php
@@ -13,11 +13,12 @@ class KafkaConsumerCommand extends Command
     protected $signature = 'kafka:consume 
             {--topics= : The topics to listen for messages (topic1,topic2,...,topicN)} 
             {--consumer= : The consumer which will consume messages in the specified topic} 
-            {--deserializer= : The deserializer class to use when consuming message}
+            {--deserializer= : The deserializer class to use when consuming message} 
+            {--clientId=anonymous : The client id} 
             {--groupId=anonymous : The consumer group id} 
             {--commit=1} 
             {--dlq=? : The Dead Letter Queue} 
-            {--maxMessage=? : The max number of messages that should be handled}
+            {--maxMessage=? : The max number of messages that should be handled} 
             {--securityProtocol=?}';
 
     protected $description = 'A Kafka Consumer for Laravel.';
@@ -30,6 +31,7 @@ class KafkaConsumerCommand extends Command
 
         $this->config = [
             'brokers' => config('kafka.brokers'),
+            'clientId' => config('kafka.client_id'),
             'groupId' => config('kafka.consumer_group_id'),
             'securityProtocol' => config('kafka.securityProtocol'),
             'sasl' => [
@@ -66,6 +68,7 @@ class KafkaConsumerCommand extends Command
             topics: $options->getTopics(),
             securityProtocol: $options->getSecurityProtocol(),
             commit: $options->getCommit(),
+            clientId: $options->getClientId(),
             groupId: $options->getGroupId(),
             consumer: app($consumer),
             sasl: $options->getSasl(),


### PR DESCRIPTION
When there are multiple consumers in the kafka broker, it helps differentiate with client names to see consumers and troubleshoot easily. 