### PR TITLE
[v2.x] Partition assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All relevant changes to `mateusjunges/laravel-kafka` will be documented here.
 - Add after and before consuming callbacks by @mateusjunges and @ebrahimradi in [#192](https://github.com/mateusjunges/laravel-kafka/pull/192)
 - Add simple events to kafka producer and consumers by @mateusjunges in [#193](https://github.com/mateusjunges/laravel-kafka/pull/193)
 - Append throwable/exception info when sending a message to DLQ by @mateusjunges in [#194](https://github.com/mateusjunges/laravel-kafka/pull/194)
+- Add the ability to assign partitions to a consumer by @mateusjunges in [#234](https://github.com/mateusjunges/laravel-kafka/pull/234)
 
 ## [2023-10-24 v1.13.5](https://github.com/mateusjunges/laravel-kafka/compare/v1.13.4...v1.13.5)
 * Fixed default securityProtocol config by @SergkeiM in [#215](https://github.com/mateusjunges/laravel-kafka/pull/215)

--- a/docs/3-installation-and-setup.md
+++ b/docs/3-installation-and-setup.md
@@ -27,20 +27,6 @@ return [
     'brokers' => env('KAFKA_BROKERS', 'localhost:9092'),
 
     /*
-     | Default security protocol
-     */
-    'securityProtocol' =>  env('KAFKA_SECURITY_PROTOCOL', 'PLAINTEXT'),
-
-    /*
-     | Default sasl configuration 
-     */
-    'sasl' => [
-        'mechanisms' => env('KAFKA_MECHANISMS', 'PLAINTEXT'),
-        'username' => env('KAFKA_USERNAME', null),
-        'password' => env('KAFKA_PASSWORD', null)
-    ],
-
-    /*
      | Kafka consumers belonging to the same consumer group share a group id.
      | The consumers in a group then divides the topic partitions as fairly amongst themselves as possible by
      | establishing that each partition is only consumed by a single consumer from the group.
@@ -95,4 +81,5 @@ return [
      */
     'cache_driver' => env('KAFKA_CACHE_DRIVER', env('CACHE_DRIVER', 'file')),
 ];
+
 ```

--- a/docs/advanced-usage/2-graceful-shutdown.md
+++ b/docs/advanced-usage/2-graceful-shutdown.md
@@ -19,7 +19,7 @@ $consumer = Kafka::createConsumer(['topic'])
     ->build()
     ->onStopConsuming(static function () {
         // Do something when the consumer stop consuming messages
-    });
+    })
 
 $consumer->consume();
 ```

--- a/docs/consuming-messages/10-class-structure.md
+++ b/docs/consuming-messages/10-class-structure.md
@@ -1,6 +1,6 @@
 ---
 title: Class structure
-weight: 9
+weight: 10
 ---
 
 Consumer classes are very simple, and it is basically a Laravel Command class. To get started, let's take a look at an example consumer.

--- a/docs/consuming-messages/11-queueable-handlers.md
+++ b/docs/consuming-messages/11-queueable-handlers.md
@@ -1,6 +1,6 @@
 ---
 title: Queueable handlers
-weight: 10
+weight: 11
 ---
 
 Queueable handlers allow you to handle your kafka messages in a queue. This will put a job into the Laravel queue system for each message received by your Kafka consumer.

--- a/docs/consuming-messages/3-assigning-partitions.md
+++ b/docs/consuming-messages/3-assigning-partitions.md
@@ -1,0 +1,31 @@
+---
+title: Assigning consumers to a topic partition
+weight: 3
+---
+
+Kafka clients allows you to implement your own partition assignment strategies for consumers.
+
+If you have a topic with multiple consumers and want to assign a consumer to a specific partition topic, you can
+use the `assignPartitions` method, available on the `ConsumerBuilder` instance:
+
+
+```php
+$partition = 1; // The partition number you want to assign
+
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()
+    ->assignPartitions([
+        new \RdKafka\TopicPartition('your-topic-name', $partition)
+    ]);
+```
+
+The `assignPartitions` method accepts an array of `\RdKafka\TopicPartition` objects. You can assign multiple partitions to the same consumer
+by adding more entries to the `assignPartitions` parameter:
+
+```php
+$consumer = \Junges\Kafka\Facades\Kafka::createConsumer()
+    ->assignPartitions([
+        new \RdKafka\TopicPartition('your-topic-name', 1)
+        new \RdKafka\TopicPartition('your-topic-name', 2)
+        new \RdKafka\TopicPartition('your-topic-name', 3)
+    ]);
+```

--- a/docs/consuming-messages/4-consumer-groups.md
+++ b/docs/consuming-messages/4-consumer-groups.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer groups
-weight: 3
+weight: 4
 ---
 
 Kafka consumers belonging to the same consumer group share a group id. The consumers in a group divides the topic partitions as fairly amongst themselves as possible by establishing that each partition is only consumed by a single consumer from the group.

--- a/docs/consuming-messages/5-message-handlers.md
+++ b/docs/consuming-messages/5-message-handlers.md
@@ -1,6 +1,6 @@
 ---
 title: Message handlers
-weight: 4
+weight: 5
 ---
 
 Now that you have created your kafka consumer, you must create a handler for the messages this consumer receives. By default, a consumer is any `callable`.

--- a/docs/consuming-messages/6-configuring-consumer-options.md
+++ b/docs/consuming-messages/6-configuring-consumer-options.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring consumer options
-weight: 5
+weight: 6
 ---
 
 The `ConsumerBuilder` offers you some few configuration options:

--- a/docs/consuming-messages/7-custom-deserializers.md
+++ b/docs/consuming-messages/7-custom-deserializers.md
@@ -1,6 +1,6 @@
 ---
 title: Custom deserializers
-weight: 6
+weight: 7
 ---
 
 To create a custom deserializer, you need to create a class that implements the `\Junges\Kafka\Contracts\MessageDeserializer` contract.

--- a/docs/consuming-messages/8-consuming-messages.md
+++ b/docs/consuming-messages/8-consuming-messages.md
@@ -1,6 +1,6 @@
 ---
 title: Consuming messages
-weight: 7
+weight: 8
 ---
 
 After building the consumer, you must call the `consume` method to consume the messages:

--- a/docs/consuming-messages/9-handling-message-batch.md
+++ b/docs/consuming-messages/9-handling-message-batch.md
@@ -1,6 +1,6 @@
 ---
 title: Handling message batch
-weight: 8
+weight: 9
 ---
 
 If you want to handle multiple messages at once, you can build your consumer enabling batch settings. 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -5,6 +5,7 @@ namespace Junges\Kafka\Config;
 use JetBrains\PhpStorm\Pure;
 use Junges\Kafka\Contracts\Consumer;
 use Junges\Kafka\Contracts\HandlesBatchConfiguration;
+use RdKafka\TopicPartition;
 
 class Config
 {
@@ -80,6 +81,7 @@ class Config
         private readonly array $callbacks = [],
         private readonly array $beforeConsumingCallbacks = [],
         private readonly array $afterConsumingCallbacks = [],
+        private readonly array $partitionAssignments = [],
     ) {
     }
 
@@ -205,5 +207,16 @@ class Config
     public function shouldSendToDlq(): bool
     {
         return $this->dlq !== null;
+    }
+
+    public function shouldAssignTopicPartitions(): bool
+    {
+        return $this->getPartitionAssigment() !== [];
+    }
+
+    /** @return array<int, TopicPartition> */
+    public function getPartitionAssigment(): array
+    {
+        return $this->partitionAssignments;
     }
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -81,7 +81,7 @@ class Config
         private readonly array $callbacks = [],
         private readonly array $beforeConsumingCallbacks = [],
         private readonly array $afterConsumingCallbacks = [],
-        private readonly array $partitionAssignments = [],
+        private readonly array $partitionAssignment = [],
     ) {
     }
 
@@ -217,6 +217,6 @@ class Config
     /** @return array<int, TopicPartition> */
     public function getPartitionAssigment(): array
     {
-        return $this->partitionAssignments;
+        return $this->partitionAssignment;
     }
 }

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -94,6 +94,10 @@ class Consumer implements MessageConsumer
             'conf' => $this->setConf($this->config->getProducerOptions()),
         ]);
 
+        if ($this->config->shouldAssignTopicPartitions()) {
+            $this->consumer->assign($this->config->getPartitionAssigment());
+        }
+
         $this->committer = $this->committerFactory->make($this->consumer, $this->config);
 
         $this->consumer->subscribe($this->config->getTopics());

--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -52,7 +52,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
     protected array $afterConsumingCallbacks = [];
 
     /** @var array<int, TopicPartition> */
-    protected array $partitionAssignments = [];
+    protected array $partitionAssignment = [];
 
     protected function __construct(protected string $brokers, array $topics = [], protected ?string $groupId = null)
     {
@@ -291,7 +291,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
             }
         }
 
-        $this->partitionAssignments = $partitionAssignment;
+        $this->partitionAssignment = $partitionAssignment;
 
         return $this;
     }
@@ -317,7 +317,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
             callbacks: $this->callbacks,
             beforeConsumingCallbacks: $this->beforeConsumingCallbacks,
             afterConsumingCallbacks: $this->afterConsumingCallbacks,
-            partitionAssignments: $this->partitionAssignments,
+            partitionAssignments: $this->partitionAssignment,
         );
 
         return new Consumer($config, $this->deserializer, $this->committerFactory);

--- a/src/Consumers/ConsumerBuilder.php
+++ b/src/Consumers/ConsumerBuilder.php
@@ -317,7 +317,7 @@ class ConsumerBuilder implements ConsumerBuilderContract
             callbacks: $this->callbacks,
             beforeConsumingCallbacks: $this->beforeConsumingCallbacks,
             afterConsumingCallbacks: $this->afterConsumingCallbacks,
-            partitionAssignments: $this->partitionAssignment,
+            partitionAssignment: $this->partitionAssignment,
         );
 
         return new Consumer($config, $this->deserializer, $this->committerFactory);


### PR DESCRIPTION
Kafka Clients allows you to implement your own partition assignment strategies for consumers.

This PR allows to specify which partitions a consumer should consume from.

In the following example, this consumer will only consume messages from the `my-awesome-topic` partitions `2`, and `3`. Messages from any other partition won't be handled by this consumer.

```php
Kafka::createConsumer()
    ->assignPartitions([
        new TopicPartition('my-awesome-topic', 2),
        new TopicPartition('my-awesome-topic', 3),
    ])
    ->withHandler(function (ConsumedMessage $message) {
        // Handle the message here
    })->build();

$consumer->consume();
```