### PR TITLE
Passthru missing methods on `KafkaFake` for macro accessibility

### DIFF
--- a/src/Contracts/KafkaManager.php
+++ b/src/Contracts/KafkaManager.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Junges\Kafka\Contracts;
+
+interface KafkaManager extends ConsumeMessagesFromKafka, MessagePublisher
+{
+
+}

--- a/src/Facades/Kafka.php
+++ b/src/Facades/Kafka.php
@@ -24,7 +24,7 @@ class Kafka extends Facade
     /** Replace the bound instance with a fake. */
     public static function fake(): KafkaFake
     {
-        static::swap($fake = new KafkaFake());
+        static::swap($fake = new KafkaFake(static::getFacadeRoot()));
 
         return $fake;
     }

--- a/src/Kafka.php
+++ b/src/Kafka.php
@@ -5,11 +5,12 @@ namespace Junges\Kafka;
 use Illuminate\Support\Traits\Macroable;
 use Junges\Kafka\Consumers\ConsumerBuilder;
 use Junges\Kafka\Contracts\ConsumeMessagesFromKafka;
+use Junges\Kafka\Contracts\KafkaManager;
 use Junges\Kafka\Contracts\MessageProducer;
 use Junges\Kafka\Contracts\MessagePublisher;
 use Junges\Kafka\Producers\ProducerBuilder;
 
-class Kafka implements MessagePublisher, ConsumeMessagesFromKafka
+class Kafka implements KafkaManager
 {
     use Macroable;
 

--- a/src/Providers/LaravelKafkaServiceProvider.php
+++ b/src/Providers/LaravelKafkaServiceProvider.php
@@ -7,6 +7,7 @@ use Junges\Kafka\Console\Commands\ConsumerCommand;
 use Junges\Kafka\Console\Commands\RestartConsumersCommand;
 use Junges\Kafka\Contracts\ConsumeMessagesFromKafka;
 use Junges\Kafka\Contracts\ConsumerMessage;
+use Junges\Kafka\Contracts\KafkaManager;
 use Junges\Kafka\Contracts\Logger as LoggerContract;
 use Junges\Kafka\Contracts\MessageDeserializer;
 use Junges\Kafka\Contracts\MessagePublisher;
@@ -46,6 +47,8 @@ class LaravelKafkaServiceProvider extends ServiceProvider
         $this->app->bind(MessagePublisher::class, Kafka::class);
 
         $this->app->bind(ConsumeMessagesFromKafka::class, Kafka::class);
+
+        $this->app->bind(KafkaManager::class, Kafka::class);
 
         $this->app->singleton(LoggerContract::class, Logger::class);
     }

--- a/tests/KafkaFakeTest.php
+++ b/tests/KafkaFakeTest.php
@@ -584,9 +584,7 @@ final class KafkaFakeTest extends LaravelKafkaTestCase
     /** @test */
     public function it_can_handle_macros(): void
     {
-        Kafka::macro('onTopicExample', function () {
-            return 'this is a test';
-        });
+        Kafka::macro('onTopicExample', fn () => 'this is a test');
 
         $this->assertSame('this is a test', $this->fake->onTopicExample());
     }

--- a/tests/KafkaFakeTest.php
+++ b/tests/KafkaFakeTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Junges\Kafka\Contracts\ConsumerMessage;
+use Junges\Kafka\Contracts\KafkaManager;
 use Junges\Kafka\Contracts\MessageConsumer;
 use Junges\Kafka\Facades\Kafka;
 use Junges\Kafka\Message\ConsumedMessage;
@@ -23,7 +24,7 @@ final class KafkaFakeTest extends LaravelKafkaTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->fake = new KafkaFake();
+        $this->fake = new KafkaFake(app(KafkaManager::class));
     }
 
     public function testItStorePublishedMessagesOnArray(): void
@@ -577,5 +578,18 @@ final class KafkaFakeTest extends LaravelKafkaTestCase
         $this->assertTrue((bool)$stopped);
         //should have consumed only two messages
         $this->assertEquals(2, $this->consumer->consumedMessagesCount());
+    }
+
+
+    /** @test */
+    public function it_can_handle_macros(): void
+    {
+        Kafka::macro('onTopicExample', function () {
+            return 'this is a test';
+        });
+
+        Kafka::fake();
+
+        $this->assertSame('this is a test', Kafka::onTopicExample());
     }
 }

--- a/tests/KafkaFakeTest.php
+++ b/tests/KafkaFakeTest.php
@@ -590,6 +590,6 @@ final class KafkaFakeTest extends LaravelKafkaTestCase
 
         Kafka::fake();
 
-        $this->assertSame('this is a test', Kafka::onTopicExample());
+        $this->assertSame('this is a test', $this->fake->onTopicExample());
     }
 }

--- a/tests/KafkaFakeTest.php
+++ b/tests/KafkaFakeTest.php
@@ -588,8 +588,6 @@ final class KafkaFakeTest extends LaravelKafkaTestCase
             return 'this is a test';
         });
 
-        Kafka::fake();
-
         $this->assertSame('this is a test', $this->fake->onTopicExample());
     }
 }


### PR DESCRIPTION
This PR implements `ForwardCalls` trait onto the `KafkaFake` class so that macro'd methods are still accessible after calling `Kafka::fake()`