### PR TITLE
[v1.13.x] Passthru missing methods on KafkaFake for macro accessibility

### DIFF
--- a/src/Facades/Kafka.php
+++ b/src/Facades/Kafka.php
@@ -28,7 +28,7 @@ class Kafka extends Facade
      */
     public static function fake(): KafkaFake
     {
-        static::swap($fake = new KafkaFake());
+        static::swap($fake = new KafkaFake(static::getFacadeRoot()));
 
         return $fake;
     }

--- a/src/Support/Testing/Fakes/KafkaFake.php
+++ b/src/Support/Testing/Fakes/KafkaFake.php
@@ -3,7 +3,9 @@
 namespace Junges\Kafka\Support\Testing\Fakes;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Traits\ForwardsCalls;
 use JetBrains\PhpStorm\Pure;
+use Junges\Kafka\Contracts\CanConsumeMessagesFromKafka;
 use Junges\Kafka\Contracts\CanPublishMessagesToKafka;
 use Junges\Kafka\Contracts\KafkaConsumerMessage;
 use Junges\Kafka\Contracts\KafkaProducerMessage;
@@ -12,12 +14,17 @@ use PHPUnit\Framework\Assert as PHPUnit;
 
 class KafkaFake implements CanPublishMessagesToKafka
 {
+    use ForwardsCalls;
+
+    private CanPublishMessagesToKafka&CanConsumeMessagesFromKafka $manager;
+
     private array $publishedMessages = [];
     /** @var \Junges\Kafka\Contracts\KafkaConsumerMessage[] */
     private array $messagesToConsume = [];
 
-    public function __construct()
+    public function __construct(CanPublishMessagesToKafka&CanConsumeMessagesFromKafka $manager)
     {
+        $this->manager = $manager;
         $this->makeProducerBuilderFake();
     }
 
@@ -212,5 +219,10 @@ class KafkaFake implements CanPublishMessagesToKafka
     private function getPublishedMessages(): array
     {
         return $this->publishedMessages;
+    }
+
+    public function __call(string $method, array $arguments)
+    {
+        return  $this->forwardCallTo($this->manager, $method, $arguments);
     }
 }

--- a/tests/KafkaFakeTest.php
+++ b/tests/KafkaFakeTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use Junges\Kafka\Contracts\CanConsumeMessages;
 use Junges\Kafka\Contracts\KafkaConsumerMessage;
 use Junges\Kafka\Facades\Kafka;
+use Junges\Kafka\Kafka as KafkaManager;
 use Junges\Kafka\Message\ConsumedMessage;
 use Junges\Kafka\Message\Message;
 use Junges\Kafka\Producers\MessageBatch;
@@ -23,7 +24,7 @@ class KafkaFakeTest extends LaravelKafkaTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->fake = new KafkaFake();
+        $this->fake = new KafkaFake(new KafkaManager());
     }
 
     public function testItStorePublishedMessagesOnArray(): void
@@ -569,5 +570,13 @@ class KafkaFakeTest extends LaravelKafkaTestCase
         $this->assertTrue((bool)$stopped);
         //should have consumed only two messages
         $this->assertEquals(2, $this->consumer->consumedMessagesCount());
+    }
+
+    /** @test */
+    public function it_can_handle_macros(): void
+    {
+        Kafka::macro('onTopicExample', fn () => 'this is a test');
+
+        $this->assertSame('this is a test', $this->fake->onTopicExample());
     }
 }


### PR DESCRIPTION
This is the version of #246 but for v1.13.x