### PR TITLE
Allow to test macroed consumers

### DIFF
--- a/src/Contracts/Manager.php
+++ b/src/Contracts/Manager.php
@@ -11,4 +11,7 @@ interface Manager
     public function consumer(array $topics = [], string $groupId = null, string $brokers = null): ConsumerBuilder;
 
     public function shouldFake(): self;
+
+    /** @param array<int, ConsumerMessage> $messages */
+    public function shouldReceiveMessages(array $messages): self;
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -4,6 +4,7 @@ namespace Junges\Kafka;
 
 use Illuminate\Support\Traits\Macroable;
 use Junges\Kafka\Consumers\Builder as ConsumerBuilder;
+use Junges\Kafka\Contracts\ConsumerMessage;
 use Junges\Kafka\Contracts\Manager;
 use Junges\Kafka\Contracts\MessageProducer;
 use Junges\Kafka\Facades\Kafka;
@@ -14,6 +15,9 @@ class Factory implements Manager
     use Macroable;
 
     private bool $shouldFake = false;
+
+    /** @var array<int, ConsumerMessage> $fakeMessages This array is passed to the underlying consumer when faking macroed consumers. */
+    private array $fakeMessages = [];
 
     /** Creates a new ProducerBuilder instance, setting brokers and topic. */
     public function publish(string $broker = null): MessageProducer
@@ -35,7 +39,7 @@ class Factory implements Manager
                 $topics,
                 $groupId,
                 $brokers
-            );
+            )->setMessages($this->fakeMessages);
         }
 
         return ConsumerBuilder::create(
@@ -48,6 +52,14 @@ class Factory implements Manager
     public function shouldFake(): self
     {
         $this->shouldFake = true;
+
+        return $this;
+    }
+
+    /** @param array<int, ConsumerMessage> $messages */
+    public function shouldReceiveMessages(array $messages): self
+    {
+        $this->fakeMessages = $messages;
 
         return $this;
     }

--- a/src/Support/Testing/Fakes/KafkaFake.php
+++ b/src/Support/Testing/Fakes/KafkaFake.php
@@ -165,6 +165,8 @@ class KafkaFake
      */
     public function __call(string $method, array $parameters)
     {
+        $this->kafkaManager->shouldReceiveMessages($this->messagesToConsume);
+
         return $this->forwardCallTo($this->kafkaManager, $method, $parameters);
     }
 }

--- a/tests/Consumers/ConsumerTest.php
+++ b/tests/Consumers/ConsumerTest.php
@@ -415,6 +415,7 @@ final class ConsumerTest extends LaravelKafkaTestCase
             ),
         ]);
 
+        /** @var MessageConsumer $consumer */
         $consumer = Kafka::macroedConsumer('change-key-to-true')->build();
         $consumer->consume();
 

--- a/tests/Consumers/ConsumerTest.php
+++ b/tests/Consumers/ConsumerTest.php
@@ -20,6 +20,7 @@ use Junges\Kafka\Message\Deserializers\JsonDeserializer;
 use Junges\Kafka\Tests\Fakes\FakeConsumer;
 use Junges\Kafka\Tests\Fakes\FakeHandler;
 use Junges\Kafka\Tests\LaravelKafkaTestCase;
+use PHPUnit\Framework\Attributes\Test;
 use RdKafka\Message;
 
 final class ConsumerTest extends LaravelKafkaTestCase
@@ -389,5 +390,34 @@ final class ConsumerTest extends LaravelKafkaTestCase
         $this->assertInstanceOf(ConsumedMessage::class, $fakeHandler->lastMessage());
         $this->assertSame(2, $this->countBeforeConsuming);
         $this->assertSame(2, $this->countAfterConsuming);
+    }
+
+    #[Test]
+    public function it_can_test_macroed_consumers(): void
+    {
+        $array = ['key' => false];
+        Kafka::macro('macroedConsumer', function (string $topic) use (&$array) {
+            return $this->consumer([$topic])->withHandler(function () use (&$array) {
+                $array['key'] = true;
+            });
+        });
+
+        Kafka::fake();
+        Kafka::shouldReceiveMessages([
+            new ConsumedMessage(
+                topicName: 'change-key-to-true',
+                partition: 0,
+                headers: [],
+                body: ['post_id' => 1],
+                key: null,
+                offset: 0,
+                timestamp: 0
+            ),
+        ]);
+
+        $consumer = Kafka::macroedConsumer('change-key-to-true')->build();
+        $consumer->consume();
+
+        $this->assertTrue($array['key']);
     }
 }


### PR DESCRIPTION
This PR allows macroed consumers to be tested. 
Since macro calls are forwared to the actual kafka manager instance instead of the fake implementation, that class had no access to the mocked messages.
