### PR TITLE
Fixed type errors caused by `commit` having an irregular type

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -67,7 +67,7 @@ class Config
         private readonly string $broker,
         private readonly array $topics,
         private readonly ?string $securityProtocol = null,
-        private readonly int|string|null $commit = null,
+        private readonly int $commit = 1,
         private readonly ?string $groupId = null,
         private readonly ?Consumer $consumer = null,
         private readonly ?Sasl $sasl = null,

--- a/src/Console/Commands/KafkaConsumer/Options.php
+++ b/src/Console/Commands/KafkaConsumer/Options.php
@@ -11,7 +11,7 @@ final class Options
     private ?string $consumer = null;
     private ?string $deserializer = null;
     private ?string $groupId = null;
-    private int|string|null $commit = 1;
+    private int $commit = 1;
     private ?string $dlq = null;
     private int $maxMessages = -1;
     private int $maxTime = 0;
@@ -54,9 +54,9 @@ final class Options
         return strlen((string) $this->groupId) > 1 ? $this->groupId : $this->config['groupId'];
     }
 
-    public function getCommit(): ?string
+    public function getCommit(): int
     {
-        return (string) $this->commit;
+        return $this->commit;
     }
 
     public function getDlq(): ?string


### PR DESCRIPTION
I changed 'commit' in all places to be an int with a default of 1 so that type errors no longer occur.

CONTEXT:

I get this error when trying to consume messages using this command:

command: php vendor/bin/sail artisan kafka:consume --consumer=App\Commands\Consumers\Kafka\MyConsumer --topics=my_topic --groupId=my_group --maxMessage=5000 --maxTime=3600

error: Junges\Kafka\Config\Config::getCommit(): Return value must be of type int, string returned.

The value of commit is "1".

