### PR TITLE
Mirror logic to enable fake builder set the topic name for all the messages at once

### DIFF
--- a/src/Support/Testing/Fakes/ProducerBuilderFake.php
+++ b/src/Support/Testing/Fakes/ProducerBuilderFake.php
@@ -45,6 +45,7 @@ class ProducerBuilderFake implements MessageProducer
 
     public function onTopic(string $topic): self
     {
+        $this->topic = $topic;
         $this->message->onTopic($topic);
 
         return $this;
@@ -156,6 +157,10 @@ class ProducerBuilderFake implements MessageProducer
     public function send(bool $shouldFlush = false): bool
     {
         $producer = $this->build();
+
+        if ($this->message->getTopicName() === null && $this->topic !== '') {
+            $this->message->onTopic($this->topic);
+        }
 
         return $producer->produce($this->getMessage());
     }

--- a/tests/KafkaFakeTest.php
+++ b/tests/KafkaFakeTest.php
@@ -138,6 +138,25 @@ final class KafkaFakeTest extends LaravelKafkaTestCase
         }
     }
 
+    public function testAssertPublishedOnBySpecifyingMessageObject(): void
+    {
+        $message = Message::create()->withBody(['test' => ['test']])->withHeaders(['custom' => 'header'])->withKey(Str::uuid()->toString());
+
+        $producer = $this->fake->publish()->onTopic('topic')->withMessage($message);
+
+        $producer->send();
+
+        $this->fake->assertPublished($producer->getMessage());
+
+        $this->fake->assertPublishedOn('topic', $producer->getMessage());
+
+        try {
+            $this->fake->assertPublishedOn('not-published-on-this-topic', $producer->getMessage());
+        } catch (ExpectationFailedException $exception) {
+            $this->assertThat($exception, new ExceptionMessageIsOrContains('The expected message was not published.'));
+        }
+    }
+
     public function testAssertPublishedOnTimes(): void
     {
         $producer = $this->fake->publish()


### PR DESCRIPTION
After the last fix introduced here: https://github.com/mateusjunges/laravel-kafka/pull/270
the logic was not copied also at the `ProducerBuilderFake` causing fake producer not to publish messages for the correct topics.

Now even if we pass the message details using the publisher methods or even if we do this using the `withMessage` function, the tests will operate correctly.

Cheers!