### PR TITLE
Replaced resolve helper with app to facilitate use for lumen

### DIFF
--- a/src/Consumers/Builder.php
+++ b/src/Consumers/Builder.php
@@ -79,7 +79,7 @@ class Builder implements ConsumerBuilderContract
         $this->autoCommit = config('kafka.auto_commit');
         $this->options = [];
 
-        $this->deserializer = resolve(MessageDeserializer::class);
+        $this->deserializer = app(MessageDeserializer::class);
     }
 
     /** @inheritDoc */


### PR DESCRIPTION
The purpose of this change was to allow the consumer to be created in lumen.
I had tried to create a consumer in Lumen but it failed with the error:
`Call to undefined function resolve()`

And because `resolve()` function is defined as:

```
if (! function_exists('resolve')) {
    /**
     * Resolve a service from the container.
     *
     * @param  string  $name
     * @param  array  $parameters
     * @return mixed
     */
    function resolve($name, array $parameters = [])
    {
        return app($name, $parameters);
    }
}
```

Thus we could safely replace the change with `app()` helper and it would help us in using this awesome package with Laravel.
Please review.