### PR TITLE
Add int casting to getLastRestart method

### DIFF
--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -480,6 +480,6 @@ class Consumer implements MessageConsumer
 
     protected function getLastRestart(): int
     {
-        return Cache::driver(config('kafka.cache_driver'))->get('laravel-kafka:consumer:restart', 0);
+        return (int) Cache::driver(config('kafka.cache_driver'))->get('laravel-kafka:consumer:restart', 0);
     }
 }


### PR DESCRIPTION
When cache driver is Redis and you retrieve a value from the store, it's automatically string type because of how Redis retrieves these values. Even if key "laravel-kafka:consumer:restart" is stored as an integer on RestartConsumersCommand, when retrieving, Redis will return that as a string.

The problem is the combination of strict_types=1 and type hinting. PHP can't automatically convert that to an integer, so there is a type error exception.

On this PR we cast the result of getLastRestart, so it's always an integer.