### PR TITLE
Attempt to fix invalid group id generation

### DIFF
--- a/src/Commit/RetryableCommitter.php
+++ b/src/Commit/RetryableCommitter.php
@@ -11,6 +11,7 @@ use RdKafka\Message;
 class RetryableCommitter implements Committer
 {
     private const RETRYABLE_ERRORS = [
+        RD_KAFKA_RESP_ERR_ILLEGAL_GENERATION,
         RD_KAFKA_RESP_ERR_REQUEST_TIMED_OUT,
     ];
     private readonly Retryable $retryable;


### PR DESCRIPTION
This PR marks the `RD_KAFKA_RESP_ERR_ILLEGAL_GENERATION` error as retryable as an attempt to fix #295 