### PR TITLE
Do not override topic when publishing batch messages

### DIFF
--- a/docs/producing-messages/6-producing-message-batch-to-kafka.md
+++ b/docs/producing-messages/6-producing-message-batch-to-kafka.md
@@ -20,7 +20,8 @@ use Junges\Kafka\Message\Message;
 $message = new Message(
     headers: ['header-key' => 'header-value'],
     body: ['key' => 'value'],
-    key: 'kafka key here'  
+    key: 'kafka key here',
+    topicName: 'my_topic'
 )
 
 $messageBatch = new MessageBatch();
@@ -36,3 +37,8 @@ $producer = Kafka::publish('broker')
 
 $producer->sendBatch($messageBatch);
 ```
+
+When producing batch messages, you can specify the topic for each message that you want to publish. If you want to publish all messages in the same topic,
+you can use the `onTopic` method on the `MessageBatch` class to specify the topic once for all messages. Please note that
+if a message within the batch specifies a topic, we will use that topic to publish the message, instead of the topic defined on the 
+batch itself.

--- a/src/Producers/Producer.php
+++ b/src/Producers/Producer.php
@@ -78,11 +78,7 @@ class Producer implements ProducerContract
     /** @inheritDoc */
     public function produceBatch(MessageBatch $messageBatch): int
     {
-        if ($messageBatch->getTopicName() === '') {
-            throw CouldNotPublishMessageBatch::invalidTopicName($messageBatch->getTopicName());
-        }
-
-        $topic = $this->producer->newTopic($messageBatch->getTopicName());
+        $this->assertTopicWasSetForAllBatchMessages($messageBatch);
 
         $messagesIterator = $messageBatch->getMessages();
 
@@ -94,7 +90,13 @@ class Producer implements ProducerContract
 
         foreach ($messagesIterator as $message) {
             assert($message instanceof Message);
-            $message->onTopic($messageBatch->getTopicName());
+
+            if ($message->getTopicName() === null) {
+                $message->onTopic($messageBatch->getTopicName());
+            }
+
+            $topic = $this->producer->newTopic($message->getTopicName());
+
             $message = $this->serializer->serialize($message);
 
             $this->produceMessageBatch($topic, $message, $messageBatch->getBatchUuid());
@@ -109,6 +111,30 @@ class Producer implements ProducerContract
         $this->dispatcher->dispatch(new MessageBatchPublished($messageBatch, $produced));
 
         return $produced;
+    }
+
+    /** @throws CouldNotPublishMessageBatch */
+    private function assertTopicWasSetForAllBatchMessages(MessageBatch $batch): void
+    {
+        // If the message batch has a topic set, we can return here because
+        // we can use that topic as a fallback in case not all batch
+        // messages have a specific topic to be used.
+        if ($batch->getTopicName() !== '') {
+            return;
+        }
+
+        $messagesIterator = $batch->getMessages();
+
+        foreach ($messagesIterator as $message) {
+            assert($message instanceof Message);
+
+            // If the batch does not have a topic defined, we check if the message
+            // itself has specified a topic in which it should be published.
+            // If it does not, then we throw an exception.
+            if ($message->getTopicName() === '' || $message->getTopicName() === null) {
+                throw CouldNotPublishMessageBatch::invalidTopicName($message->getTopicName() ?? '');
+            }
+        }
     }
 
     private function produceMessage(ProducerTopic $topic, ProducerMessage $message): void


### PR DESCRIPTION
Currently, when sending batch messages, if a message in the batch specifies a topic, it is overwritten when the batch is being produced. This PR fixes this behavior.

Fix #308 