### PR TITLE
Allow to reset the Kafka Manager

### DIFF
--- a/docs/producing-messages/1-producing-messages.md
+++ b/docs/producing-messages/1-producing-messages.md
@@ -24,3 +24,15 @@ Kafka::asyncPublish('broker')->onTopic('topic-name')
 
 The main difference is that the Async Producer is a singleton and will only flush the producer when the application is shutting down, instead of after each send or batch send. 
 This reduces the overhead when you want to send a lot of messages in your request handlers. 
+
+When doing async publishing, the builder is stored in memory during the entire request. If you need to use a fresh producer, you may use the `fresh` method
+available on the `Kafka` facade (added in v2.2.0). This method will return a fresh Kafka Manager, which you can use to produce messages with a newly created producer builder.
+
+
+```php
+use Junges\Kafka\Facades\Kafka;
+
+Kafka::fresh()
+    ->asyncPublish('broker')
+    ->onTopic('topic-name')
+```

--- a/src/Contracts/Manager.php
+++ b/src/Contracts/Manager.php
@@ -4,6 +4,9 @@ namespace Junges\Kafka\Contracts;
 
 interface Manager
 {
+    /** Returns a new fresh instance of the Manager. */
+    public function fresh(): self;
+
     /** Creates a new ProducerBuilder instance, setting brokers and topic. */
     public function publish(?string $broker = null): MessageProducer;
 

--- a/src/Facades/Kafka.php
+++ b/src/Facades/Kafka.php
@@ -9,6 +9,7 @@ use Junges\Kafka\Support\Testing\Fakes\KafkaFake;
 /**
  * @method static \Junges\Kafka\Contracts\MessageProducer publish(string $broker = null)
  * @method static \Junges\Kafka\Contracts\MessageProducer asyncPublish(string $broker = null)
+ * @method static \Junges\Kafka\Factory fresh(string $broker = null)
  * @method static \Junges\Kafka\Consumers\Builder consumer(array $topics = [], string $groupId = null, string $brokers = null)
  * @method static void assertPublished(ProducerMessage $expectedMessage = null, callable $callback = null)
  * @method static void assertPublishedTimes(int $times = 1, ProducerMessage $expectedMessage = null, callable $callback = null)

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -33,6 +33,12 @@ class Factory implements Manager
         );
     }
 
+    /** Returns a fresh factory instance. */
+    public function fresh(): self
+    {
+        return new self;
+    }
+
     /**
      * Creates a new ProducerBuilder instance, optionally setting the brokers.
      * The producer will be flushed only when the application terminates,


### PR DESCRIPTION
This PR adds the `fresh` method, which allows you to reset the Kafka manager instance.