### PR TITLE
Adds in the ability to set complete body when producing messages

### DIFF
--- a/src/Contracts/MessageProducer.php
+++ b/src/Contracts/MessageProducer.php
@@ -41,6 +41,9 @@ interface MessageProducer extends InteractsWithConfigCallbacks
     /** Set a message array key. */
     public function withBodyKey(string $key, mixed $message): self;
 
+    /** Set a message body. */
+    public function withBody(mixed $body): self;
+
     /** Set the message to be published. */
     public function withMessage(ProducerMessage $message): self;
 

--- a/src/Producers/Builder.php
+++ b/src/Producers/Builder.php
@@ -99,6 +99,14 @@ class Builder implements MessageProducer
         return $this;
     }
 
+    /** Set a message body.  */
+    public function withBody(mixed $body): self
+    {
+        $this->message->withBody($body);
+
+        return $this;
+    }
+
     public function transactional(int $maxRetryAttempts = 5): self
     {
         $this->isTransactionProducer = true;

--- a/src/Support/Testing/Fakes/ProducerBuilderFake.php
+++ b/src/Support/Testing/Fakes/ProducerBuilderFake.php
@@ -104,6 +104,14 @@ class ProducerBuilderFake implements MessageProducer
         return $this;
     }
 
+    /** Set a message body.  */
+    public function withBody(mixed $body): self
+    {
+        $this->message->withBody($body);
+
+        return $this;
+    }
+
     /** Set the entire message.  */
     public function withMessage(ProducerMessage $message): self
     {


### PR DESCRIPTION
Adds in the ability to set complete body of the produced message w/out having to completely replace the message via ->withMessage()