### PR TITLE
Fix invalid group id generation for v1.13.x

### DIFF
--- a/src/Commit/RetryableCommitter.php
+++ b/src/Commit/RetryableCommitter.php
@@ -11,6 +11,7 @@ use RdKafka\Message;
 class RetryableCommitter implements Committer
 {
     private const RETRYABLE_ERRORS = [
+        RD_KAFKA_RESP_ERR_ILLEGAL_GENERATION,
         RD_KAFKA_RESP_ERR_REQUEST_TIMED_OUT,
     ];
 


### PR DESCRIPTION
This issue was fixed in #305 , but it is currently not updated for 1.13.x versions. We are having the same issue and cannot upgrade to 2.x yet. This PR will help systems running on 1.13.x to automatically retry when encountering the "Invalid group id generation" error