### PR TITLE
Convert `KAFKA_CONSUMER_DEFAULT_TIMEOUT` to an integer to avoid type error

### DIFF
--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -191,7 +191,7 @@ class Consumer implements MessageConsumer
      */
     private function doConsume(): void
     {
-        $message = $this->consumer->consume(config('kafka.consumer_timeout_ms', 2000));
+        $message = $this->consumer->consume((int) config('kafka.consumer_timeout_ms', 2000));
         $this->handleMessage($message);
     }
 


### PR DESCRIPTION
If **KAFKA_CONSUMER_DEFAULT_TIMEOUT** is configured in the **.env** file, it will result in an error `RdKafka\KafkaConsumer::consume(): Argument #1 ($timeout_ms) must be of type int, string given`