### PR TITLE
Prefer Cache env from laravel 11

### DIFF
--- a/config/kafka.php
+++ b/config/kafka.php
@@ -73,7 +73,7 @@ return [
     /*
      | The cache driver that will be used
      */
-    'cache_driver' => env('KAFKA_CACHE_DRIVER', env('CACHE_DRIVER', 'file')),
+    'cache_driver' => env('KAFKA_CACHE_DRIVER', env('CACHE_DRIVER', env('CACHE_STORE', 'database'))),
 
     /*
      | Kafka message id key name


### PR DESCRIPTION
Laravel 11 changed new cache env key. 

This PR make use of specific kafka driver config, then laravel 10 key, then laravel 11 key, in order to find. 

Laravel 10 - https://github.com/laravel/laravel/blob/7effeb99ec1568f006ed95e60d3e7dfeed1b8160/config/cache.php#L18

Laravel 11 - https://github.com/laravel/laravel/blob/70f437b6fc7801ef11d6627d9ab48d698ffe5f26/config/cache.php#L18
