### PR TITLE
Use destruct method to flush the producer

### DIFF
--- a/src/Producers/Producer.php
+++ b/src/Producers/Producer.php
@@ -40,11 +40,12 @@ class Producer implements ProducerContract
             'conf' => $this->getConf($this->config->getProducerOptions()),
         ]);
         $this->dispatcher = App::make(Dispatcher::class);
+    }
 
+    public function __destruct()
+    {
         if ($this->async) {
-            app()->terminating(function () {
-                $this->flush();
-            });
+            $this->flush();
         }
     }
 


### PR DESCRIPTION
I had issues with the new async producer. Because the reference is captured in the terminate callback, in fact the rdkafka producer is never garbage collcted and because of that in the queue the connection to kafka is never terminated. 

That causes issue when used in the queue as new connections indeed created, but the old ones are never closed.

The solution would be to use the destructor. In that way - if you use the main facade method - the reference is kept around for a second publish, and if you do Kafka::fresh(), the message will be flushed when it foes out of scope and then when it is destroyed the connection is closed too. That works great for the Queue because the Facade cache is reset after each job execution! If someone wants to implement a persistent publisher that works cross-jobs - he can create a singleton!