### PR TITLE
Fixes manual committing

### DIFF
--- a/docs/advanced-usage/custom-committers.md
+++ b/docs/advanced-usage/custom-committers.md
@@ -41,11 +41,24 @@ $consumer = \Junges\Kafka\Facades\Kafka::consumer()
     ->build();
 ```
 
+### Manual commit support
+Custom committers support both automatic and manual commit operations. The `Committer` interface includes:
+
+- `commitMessage(Message $message, bool $success): void` - Used for automatic commits
+- `commitDlq(Message $message): void` - Used for dead letter queue commits  
+- `commit(mixed $messageOrOffsets = null): void` - Used for manual synchronous commits
+- `commitAsync(mixed $messageOrOffsets = null): void` - Used for manual asynchronous commits
+
+When handlers call `$consumer->commit()` or `$consumer->commitAsync()`, these calls are routed through your custom committer, ensuring consistent behavior across all commit types.
+
 ### Usage example
 If you want to define a new committer for you consumer, you must start by creating a new class that implements the `Committer` interface. 
-The `commitMessage` function has a `$success` param, which is true for all messages that were consumed without throwing exceptions or messages which exceptions were handled successfully by the consumer class. So, the following committer will commit only messages that were consumed withtout throwing an exception:
+The `commitMessage` function has a `$success` param, which is true for all messages that were consumed without throwing exceptions or messages which exceptions were handled successfully by the consumer class. So, the following committer will commit only messages that were consumed without throwing an exception:
 
 ```php
+use Junges\Kafka\Contracts\ConsumerMessage;
+use RdKafka\TopicPartition;
+
 class CustomCommitter implements CommitterContract
 {
     public function __construct(private KafkaConsumer $consumer) {}
@@ -62,6 +75,36 @@ class CustomCommitter implements CommitterContract
     public function commitDlq(Message $message): void
     {
         $this->consumer->commit($message);
+    }
+    
+    public function commit(mixed $messageOrOffsets = null): void
+    {
+        // Handle manual commits
+        if ($messageOrOffsets instanceof ConsumerMessage) {
+            $topicPartition = new TopicPartition(
+                $messageOrOffsets->getTopicName(),
+                $messageOrOffsets->getPartition(),
+                $messageOrOffsets->getOffset() + 1
+            );
+            $messageOrOffsets = [$topicPartition];
+        }
+
+        $this->consumer->commit($messageOrOffsets);
+    }
+
+    public function commitAsync(mixed $messageOrOffsets = null): void
+    {
+        // Handle manual async commits
+        if ($messageOrOffsets instanceof ConsumerMessage) {
+            $topicPartition = new TopicPartition(
+                $messageOrOffsets->getTopicName(),
+                $messageOrOffsets->getPartition(),
+                $messageOrOffsets->getOffset() + 1
+            );
+            $messageOrOffsets = [$topicPartition];
+        }
+
+        $this->consumer->commitAsync($messageOrOffsets);
     }
 }
 ```

--- a/docs/advanced-usage/manual-commit.md
+++ b/docs/advanced-usage/manual-commit.md
@@ -1,0 +1,261 @@
+---
+title: Manual Commit
+weight: 5
+---
+
+Manual commit gives you complete control over when message offsets are committed to Kafka. This provides stronger processing guarantees and better error handling compared to auto-commit mode.
+
+```+parse
+<x-sponsors.request-sponsor/>
+```
+
+## Overview
+
+By default, the package uses auto-commit mode where messages are automatically committed after your handler successfully processes them. With manual commit, you decide exactly when to commit messages, allowing for:
+
+- **At-least-once delivery**: Ensure messages are only committed after successful processing
+- **Better error handling**: Don't commit messages that failed to process
+- **Custom commit strategies**: Implement batch commits, conditional commits, or other patterns
+- **Performance optimization**: Use asynchronous commits for better throughput
+
+## Enabling Manual Commit
+
+To enable manual commit, set `withManualCommit()` when creating your consumer:
+
+```php
+use Junges\Kafka\Facades\Kafka;
+
+$consumer = Kafka::consumer(['my-topic'])
+    ->withManualCommit() // Disable auto-commit
+    ->withHandler(function($message, $consumer) {
+        // Your handler with manual commit control
+    })
+    ->build();
+```
+
+## Commit Methods API
+
+Your message handlers receive a `$consumer` parameter with these commit methods:
+
+### Synchronous Commits (Blocking)
+
+```php
+// Commit all current assignment offsets
+$consumer->commit();
+
+// Commit specific message offset  
+$consumer->commit($message);
+
+// Commit specific partition offsets
+$consumer->commit([$topicPartition1, $topicPartition2]);
+```
+
+### Asynchronous Commits (Non-blocking)
+
+```php
+// Commit all current assignment offsets asynchronously
+$consumer->commitAsync();
+
+// Commit specific message offset asynchronously
+$consumer->commitAsync($message);
+
+// Commit specific partition offsets asynchronously  
+$consumer->commitAsync([$topicPartition1, $topicPartition2]);
+```
+
+### Parameters
+
+All commit methods accept these parameter types:
+
+- **`null`** (default): Commit offsets for current assignment
+- **`ConsumerMessage`**: Commit offset for the specific message
+- **`RdKafka\Message`**: Commit offset for the underlying Kafka message
+- **`RdKafka\TopicPartition[]`**: Commit specific partition offsets
+
+## Basic Usage Patterns
+
+### Simple Manual Commit
+
+```php
+$consumer = Kafka::consumer(['orders'])
+    ->withManualCommit()
+    ->withHandler(function($message, $consumer) {
+        try {
+            // Process the order
+            $order = json_decode($message->getBody(), true);
+            processOrder($order);
+            
+            // Commit only after successful processing
+            $consumer->commit($message);
+            
+        } catch (Exception $e) {
+            Log::error('Order processing failed', [
+                'error' => $e->getMessage(),
+                'order_id' => $order['id'] ?? 'unknown'
+            ]);
+        }
+    });
+```
+
+### Async Commit for Better Performance
+
+```php
+$consumer->withHandler(function($message, $consumer) {
+    // Process message
+    processMessage($message);
+    
+    // Use async commit for better throughput
+    $consumer->commitAsync($message);
+    
+    // Handler can continue immediately without waiting for commit
+});
+```
+
+## Error Handling
+
+### Retry Logic with Manual Commit
+
+```php
+$consumer->withHandler(function($message, $consumer) {
+    $maxRetries = 3;
+    $attempt = 0;
+    
+    while ($attempt < $maxRetries) {
+        try {
+            processMessage($message);
+            $consumer->commit($message);
+            return; // Success
+            
+        } catch (RetryableException $e) {
+            $attempt++;
+            Log::warning("Retry attempt {$attempt}", ['error' => $e->getMessage()]);
+            
+            if ($attempt >= $maxRetries) {
+                // Send to DLQ or handle permanent failure
+                Log::error('Max retries exceeded', ['error' => $e->getMessage()]);
+                throw $e;
+            }
+            
+            sleep(pow(2, $attempt));
+            
+        } catch (Exception $e) {
+            // Non-retryable error
+            Log::error('Non-retryable error', ['error' => $e->getMessage()]);
+            throw $e;
+        }
+    }
+});
+```
+
+### Dead Letter Queue Integration
+
+Manual commit works seamlessly with DLQ functionality:
+
+```php
+$consumer = Kafka::consumer(['orders'])
+    ->withManualCommit()
+    ->withDlq('orders-dlq') // Configure DLQ
+    ->withHandler(function($message, $consumer) {
+        try {
+            processOrder($message);
+            $consumer->commit($message);
+            
+        } catch (ValidationException $e) {
+            // Don't commit - let DLQ handling take over
+            Log::error('Invalid order format', ['error' => $e->getMessage()]);
+            throw $e; // This will trigger DLQ
+        }
+    });
+```
+
+## Performance Considerations
+
+### Sync vs Async Commits
+
+- **Synchronous commits**: Slower but guarantees the commit completed
+- **Asynchronous commits**: Faster but fire-and-forget
+
+```php
+// High-throughput scenario - use async
+$consumer->commitAsync($message);
+
+// Critical data - use sync for guarantee
+$consumer->commit($message);
+```
+
+### Batch Commit Optimization
+
+```php
+$consumer->withHandler(function($message, $consumer) {
+    static $messages = [];
+    
+    // Collect messages
+    $messages[] = $message;
+    
+    // Batch commit every 100 messages
+    if (count($messages) >= 100) {
+        // Process all messages
+        foreach ($messages as $msg) {
+            processMessage($msg);
+        }
+        
+        // Commit the last message's offset (commits all previous)
+        $consumer->commitAsync(end($messages));
+        $messages = [];
+    }
+});
+```
+
+## Migration from Auto-Commit
+
+To migrate existing auto-commit consumers to manual commit:
+
+### Before (Auto-commit)
+```php
+$consumer = Kafka::consumer(['topic'])
+    ->withAutoCommit()  // or omit, it's the default
+    ->withHandler(function($message, $consumer) {
+        processMessage($message);
+    });
+```
+
+### After (Manual commit)
+```php
+$consumer = Kafka::consumer(['topic'])
+    ->withManualCommit() // Enable manual control
+    ->withHandler(function($message, $consumer) {
+        try {
+            processMessage($message);
+            $consumer->commit($message); // Explicit commit
+        } catch (Exception $e) {
+            // Handle errors without committing
+            Log::error('Processing failed', ['error' => $e->getMessage()]);
+        }
+    });
+```
+
+## Best Practices
+
+1. **Always commit after successful processing**: Only commit messages that were fully processed
+2. **Use async commits for performance**: Unless you need commit guarantees, use `commitAsync()`
+3. **Implement proper error handling**: Don't commit messages that failed to process
+4. **Handle duplicate processing**: Manual commit provides at-least-once delivery, so implement idempotent processing
+
+## Troubleshooting
+
+### Common Issues
+
+**Messages being reprocessed repeatedly:**
+- Check that you're calling `commit()` after successful processing
+- Ensure exceptions don't prevent the commit call
+- Verify your error handling doesn't commit failed messages
+
+**Poor performance:**
+- Use `commitAsync()` instead of `commit()` for better throughput
+- Implement batch commits for high-volume scenarios
+- Avoid committing every single message in high-throughput scenarios
+
+**Offset commit errors:**
+- Check Kafka broker connectivity
+- Verify consumer group permissions
+- Monitor Kafka logs for commit-related errors

--- a/docs/consuming-messages/class-structure.md
+++ b/docs/consuming-messages/class-structure.md
@@ -28,6 +28,7 @@ class MyTopicConsumer extends Command
             ->withAutoCommit()
             ->withHandler(function(ConsumerMessage $message, MessageConsumer $consumer) {
                 // Handle your message here
+                // For manual commit control, use ->withManualCommit() and call $consumer->commit($message)
             })
             ->build();
             

--- a/docs/consuming-messages/message-handlers.md
+++ b/docs/consuming-messages/message-handlers.md
@@ -37,6 +37,98 @@ The `ConsumerMessage` contract gives you some handy methods to get the message p
 - `getBody()`: Returns the body of the message
 - `getOffset()`: Returns the offset where the message was published
 
+## Manual Commit in Handlers
+
+When using manual commit mode (`withAutoCommit(false)`), your handlers receive a `$consumer` parameter that provides commit methods. This allows you to control exactly when message offsets are committed:
+
+```php
+$consumer = \Junges\Kafka\Facades\Kafka::consumer()
+    ->withAutoCommit(false)  // Enable manual commit mode
+    ->withHandler(function(\Junges\Kafka\Contracts\ConsumerMessage $message, \Junges\Kafka\Contracts\MessageConsumer $consumer) {
+        try {
+            // Process your message
+            $data = json_decode($message->getBody(), true);
+            processBusinessLogic($data);
+            
+            // Commit the message after successful processing
+            $consumer->commit($message);
+            
+        } catch (ValidationException $e) {
+            // Don't commit invalid messages, send to DLQ or handle differently
+            Log::warning('Invalid message format', ['message' => $message->getBody()]);
+            
+        } catch (Exception $e) {
+            Log::error('Processing failed', ['error' => $e->getMessage()]);
+            throw $e;
+        }
+    });
+```
+
+### Available Commit Methods
+
+The `$consumer` parameter provides these commit methods:
+
+**Synchronous commits** (blocking):
+- `$consumer->commit()` - Commit current assignment offsets
+- `$consumer->commit($message)` - Commit specific message offset
+
+**Asynchronous commits** (non-blocking, better performance):
+- `$consumer->commitAsync()` - Commit current assignment offsets
+- `$consumer->commitAsync($message)` - Commit specific message offset
+
+
+## Handler Classes
+
+You can also create dedicated handler classes by implementing the `Handler` interface. Handler classes receive both the message and consumer parameters, just like closure handlers:
+
+```php
+use Junges\Kafka\Contracts\Handler;
+use Junges\Kafka\Contracts\ConsumerMessage;
+use Junges\Kafka\Contracts\MessageConsumer;
+
+class ProcessOrderHandler implements Handler
+{
+    public function __invoke(ConsumerMessage $message, MessageConsumer $consumer): void
+    {
+        try {
+            $order = json_decode($message->getBody(), true);
+            
+            // Process the order
+            $this->processOrder($order);
+            
+            // Manual commit after successful processing
+            $consumer->commit($message);
+            
+        } catch (ValidationException $e) {
+            // Don't commit invalid messages
+            Log::warning('Invalid order data', ['message' => $message->getBody()]);
+            
+        } catch (Exception $e) {
+            // Don't commit on processing errors
+            Log::error('Order processing failed', ['error' => $e->getMessage()]);
+            throw $e; // Re-throw to trigger DLQ handling if configured
+        }
+    }
+    
+    private function processOrder(array $order): void
+    {
+        // Your business logic here
+    }
+}
+```
+
+**Using Handler classes with the consumer:**
+
+```php
+use Junges\Kafka\Facades\Kafka;
+
+$consumer = Kafka::consumer(['orders'])
+    ->withAutoCommit(false)  // Enable manual commit mode
+    ->withHandler(new ProcessOrderHandler())
+    ->build();
+
+$consumer->consume();
+```
 
 ```+parse
 <x-sponsors.request-sponsor/>

--- a/src/Commit/BatchCommitter.php
+++ b/src/Commit/BatchCommitter.php
@@ -37,4 +37,14 @@ class BatchCommitter implements Committer
         $this->committer->commitDlq($message);
         $this->commits = 0;
     }
+
+    public function commit(mixed $messageOrOffsets = null): void
+    {
+        $this->committer->commit($messageOrOffsets);
+    }
+
+    public function commitAsync(mixed $messageOrOffsets = null): void
+    {
+        $this->committer->commitAsync($messageOrOffsets);
+    }
 }

--- a/src/Commit/Committer.php
+++ b/src/Commit/Committer.php
@@ -3,8 +3,10 @@
 namespace Junges\Kafka\Commit;
 
 use Junges\Kafka\Contracts\Committer as CommitterContract;
+use Junges\Kafka\Contracts\ConsumerMessage;
 use RdKafka\KafkaConsumer;
 use RdKafka\Message;
+use RdKafka\TopicPartition;
 
 class Committer implements CommitterContract
 {
@@ -22,5 +24,35 @@ class Committer implements CommitterContract
     public function commitDlq(Message $message): void
     {
         $this->consumer->commit($message);
+    }
+
+    /** @throws \RdKafka\Exception */
+    public function commit(mixed $messageOrOffsets = null): void
+    {
+        if ($messageOrOffsets instanceof ConsumerMessage) {
+            $topicPartition = new TopicPartition(
+                $messageOrOffsets->getTopicName(),
+                $messageOrOffsets->getPartition(),
+                $messageOrOffsets->getOffset() + 1
+            );
+            $messageOrOffsets = [$topicPartition];
+        }
+
+        $this->consumer->commit($messageOrOffsets);
+    }
+
+    /** @throws \RdKafka\Exception */
+    public function commitAsync(mixed $messageOrOffsets = null): void
+    {
+        if ($messageOrOffsets instanceof ConsumerMessage) {
+            $topicPartition = new TopicPartition(
+                $messageOrOffsets->getTopicName(),
+                $messageOrOffsets->getPartition(),
+                $messageOrOffsets->getOffset() + 1
+            );
+            $messageOrOffsets = [$topicPartition];
+        }
+
+        $this->consumer->commitAsync($messageOrOffsets);
     }
 }

--- a/src/Commit/DefaultCommitterFactory.php
+++ b/src/Commit/DefaultCommitterFactory.php
@@ -16,10 +16,6 @@ class DefaultCommitterFactory implements CommitterFactory
 
     public function make(KafkaConsumer $kafkaConsumer, Config $config): CommitterContract
     {
-        if (! $config->isAutoCommit()) {
-            return new VoidCommitter();
-        }
-
         return new BatchCommitter(
             new RetryableCommitter(
                 new Committer(

--- a/src/Commit/RetryableCommitter.php
+++ b/src/Commit/RetryableCommitter.php
@@ -34,4 +34,16 @@ class RetryableCommitter implements Committer
     {
         $this->retryable->retry(fn () => $this->committer->commitDlq($message));
     }
+
+    /** @throws \Carbon\Exceptions\Exception */
+    public function commit(mixed $messageOrOffsets = null): void
+    {
+        $this->retryable->retry(fn () => $this->committer->commit($messageOrOffsets));
+    }
+
+    /** @throws \Carbon\Exceptions\Exception */
+    public function commitAsync(mixed $messageOrOffsets = null): void
+    {
+        $this->retryable->retry(fn () => $this->committer->commitAsync($messageOrOffsets));
+    }
 }

--- a/src/Commit/SeekToCurrentErrorCommitter.php
+++ b/src/Commit/SeekToCurrentErrorCommitter.php
@@ -29,4 +29,14 @@ class SeekToCurrentErrorCommitter implements Committer
     {
         $this->committer->commitDlq($message);
     }
+
+    public function commit(mixed $messageOrOffsets = null): void
+    {
+        $this->committer->commit($messageOrOffsets);
+    }
+
+    public function commitAsync(mixed $messageOrOffsets = null): void
+    {
+        $this->committer->commitAsync($messageOrOffsets);
+    }
 }

--- a/src/Commit/VoidCommitter.php
+++ b/src/Commit/VoidCommitter.php
@@ -14,4 +14,12 @@ class VoidCommitter implements Committer
     public function commitDlq(Message $message): void
     {
     }
+
+    public function commit(mixed $messageOrOffsets = null): void
+    {
+    }
+
+    public function commitAsync(mixed $messageOrOffsets = null): void
+    {
+    }
 }

--- a/src/Consumers/Builder.php
+++ b/src/Consumers/Builder.php
@@ -239,6 +239,13 @@ class Builder implements ConsumerBuilderContract
         return $this;
     }
 
+    public function withManualCommit(): self
+    {
+        $this->autoCommit = false;
+
+        return $this;
+    }
+
     /** @inheritDoc */
     public function withOptions(array $options): self
     {

--- a/src/Contracts/Committer.php
+++ b/src/Contracts/Committer.php
@@ -11,4 +11,26 @@ interface Committer
 
     /** Commits the given message to the Dead Letter Queue. */
     public function commitDlq(Message $message): void;
+
+    /**
+     * Commit offsets synchronously.
+     *
+     * @param mixed $messageOrOffsets Can be:
+     *   - null: Commit offsets for current assignment
+     *   - \RdKafka\Message: Commit offset for a single topic+partition  
+     *   - \Junges\Kafka\Contracts\ConsumerMessage: Commit offset for a single topic+partition
+     *   - array of \RdKafka\TopicPartition: Commit offsets for provided partitions
+     */
+    public function commit(mixed $messageOrOffsets = null): void;
+
+    /**
+     * Commit offsets asynchronously.
+     *
+     * @param mixed $messageOrOffsets Can be:
+     *   - null: Commit offsets for current assignment
+     *   - \RdKafka\Message: Commit offset for a single topic+partition  
+     *   - \Junges\Kafka\Contracts\ConsumerMessage: Commit offset for a single topic+partition
+     *   - array of \RdKafka\TopicPartition: Commit offsets for provided partitions
+     */
+    public function commitAsync(mixed $messageOrOffsets = null): void;
 }

--- a/src/Contracts/ConsumerBuilder.php
+++ b/src/Contracts/ConsumerBuilder.php
@@ -90,6 +90,9 @@ interface ConsumerBuilder extends InteractsWithConfigCallbacks
     /** Enable or disable consumer auto commit option. */
     public function withAutoCommit(bool $autoCommit = true): self;
 
+    /** Enables manual commit. */
+    public function withManualCommit(): self;
+
     /** Set the configuration options. */
     public function withOptions(array $options): self;
 

--- a/src/Contracts/Handler.php
+++ b/src/Contracts/Handler.php
@@ -4,5 +4,5 @@ namespace Junges\Kafka\Contracts;
 
 interface Handler
 {
-    public function __invoke(ConsumerMessage $message): void;
+    public function __invoke(ConsumerMessage $message, MessageConsumer $consumer): void;
 }

--- a/src/Contracts/MessageConsumer.php
+++ b/src/Contracts/MessageConsumer.php
@@ -19,4 +19,30 @@ interface MessageConsumer
 
     /** Count the number of messages consumed by this consumer */
     public function consumedMessagesCount(): int;
+
+    /**
+     * Commit offsets synchronously.
+     *
+     * @param mixed $messageOrOffsets Can be:
+     *   - null: Commit offsets for current assignment
+     *   - \RdKafka\Message: Commit offset for a single topic+partition  
+     *   - ConsumerMessage: Commit offset for a single topic+partition
+     *   - array of \RdKafka\TopicPartition: Commit offsets for provided partitions
+     *
+     * @throws \RdKafka\Exception
+     */
+    public function commit(mixed $messageOrOffsets = null): void;
+
+    /**
+     * Commit offsets asynchronously.
+     *
+     * @param mixed $message_or_offsets Can be:
+     *   - null: Commit offsets for current assignment
+     *   - \RdKafka\Message: Commit offset for a single topic+partition
+     *   - ConsumerMessage: Commit offset for a single topic+partition  
+     *   - array of \RdKafka\TopicPartition: Commit offsets for provided partitions
+     *
+     * @throws \RdKafka\Exception
+     */
+    public function commitAsync(mixed $message_or_offsets = null): void;
 }

--- a/src/Support/Testing/Fakes/ConsumerFake.php
+++ b/src/Support/Testing/Fakes/ConsumerFake.php
@@ -68,6 +68,18 @@ class ConsumerFake implements MessageConsumer
         return $this->messageCounter->messagesCounted();
     }
 
+    /** @inheritdoc */
+    public function commit(mixed $messageOrOffsets = null): void
+    {
+        //
+    }
+
+    /** @inheritdoc */
+    public function commitAsync(mixed $message_or_offsets = null): void
+    {
+        //
+    }
+
     /** Set the consumer configuration. */
     public function setConf(array $options = []): Conf
     {

--- a/tests/Commit/KafkaCommitterTest.php
+++ b/tests/Commit/KafkaCommitterTest.php
@@ -4,6 +4,10 @@ namespace Junges\Kafka\Tests\Commit;
 
 use Junges\Kafka\Commit\Committer;
 use Junges\Kafka\Config\Config;
+use Junges\Kafka\Consumers\CallableConsumer;
+use Junges\Kafka\Consumers\Consumer;
+use Junges\Kafka\Contracts\ConsumerMessage;
+use Junges\Kafka\Message\Deserializers\JsonDeserializer;
 use Junges\Kafka\Tests\LaravelKafkaTestCase;
 use Mockery as m;
 use PHPUnit\Framework\Attributes\Test;
@@ -71,5 +75,174 @@ final class KafkaCommitterTest extends LaravelKafkaTestCase
         ]));
 
         $kafkaCommitter->commitDlq(new Message());
+    }
+
+    #[Test]
+    public function it_allows_manual_commits_in_manual_commit_mode(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 5;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $commitCalled = false;
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commit')
+            ->andReturnUsing(function() use (&$commitCalled) {
+                $commitCalled = true;
+                return null;
+            })
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $handlerCalled = false;
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) use (&$handlerCalled) {
+                $handlerCalled = true;
+                // This should actually commit now!
+                $consumer->commit($message);
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        $this->assertTrue($handlerCalled);
+        $this->assertTrue($commitCalled, 'Manual commit should work in manual commit mode');
+    }
+
+    #[Test]
+    public function it_disables_auto_commits_in_manual_commit_mode(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 5;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commit')
+            ->never()
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $handlerCalled = false;
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) use (&$handlerCalled) {
+                $handlerCalled = true;
+                // Don't manually commit, should result in no commits
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        $this->assertTrue($handlerCalled);
+    }
+
+    #[Test]
+    public function it_enables_auto_commits_in_auto_commit_mode(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 5;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $autoCommitCalled = false;
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commit')
+            ->andReturnUsing(function() use (&$autoCommitCalled) {
+                $autoCommitCalled = true;
+                return null;
+            })
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $handlerCalled = false;
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) use (&$handlerCalled) {
+                $handlerCalled = true;
+                // Don't manually commit, auto-commit should handle it
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: true
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        $this->assertTrue($handlerCalled);
+        $this->assertTrue($autoCommitCalled, 'Auto-commit should work in auto-commit mode');
     }
 }

--- a/tests/Consumers/ConsumerTest.php
+++ b/tests/Consumers/ConsumerTest.php
@@ -11,6 +11,7 @@ use Junges\Kafka\Consumers\Consumer;
 use Junges\Kafka\Consumers\DispatchQueuedHandler;
 use Junges\Kafka\Contracts\CommitterFactory;
 use Junges\Kafka\Contracts\ConsumerMessage;
+use Junges\Kafka\Contracts\Handler;
 use Junges\Kafka\Contracts\MessageConsumer;
 use Junges\Kafka\Events\MessageConsumed;
 use Junges\Kafka\Exceptions\ConsumerException;
@@ -21,7 +22,9 @@ use Junges\Kafka\Tests\Fakes\FakeConsumer;
 use Junges\Kafka\Tests\Fakes\FakeHandler;
 use Junges\Kafka\Tests\LaravelKafkaTestCase;
 use PHPUnit\Framework\Attributes\Test;
+use RdKafka\KafkaConsumer;
 use RdKafka\Message;
+use Mockery as m;
 
 final class ConsumerTest extends LaravelKafkaTestCase
 {
@@ -466,5 +469,178 @@ final class ConsumerTest extends LaravelKafkaTestCase
         $consumer->consume();
 
         $this->assertTrue($array['key']);
+    }
+
+    #[Test]
+    public function it_provides_consumer_to_handler_classes(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 5;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $handlerCalled = false;
+        $consumerProvided = false;
+        $messageData = null;
+
+        $handler = new class($handlerCalled, $consumerProvided, $messageData) implements Handler {
+            public function __construct(
+                private bool &$handlerCalledRef,
+                private bool &$consumerProvidedRef,
+                private mixed &$messageDataRef
+            ) {}
+
+            public function __invoke(ConsumerMessage $message, MessageConsumer $consumer): void
+            {
+                $this->handlerCalledRef = true;
+                $this->consumerProvidedRef = $consumer !== null;
+                $this->messageDataRef = [
+                    'topic' => $message->getTopicName(),
+                    'partition' => $message->getPartition(),
+                    'offset' => $message->getOffset(),
+                    'has_consumer' => $consumer !== null,
+                    'can_commit' => method_exists($consumer, 'commit')
+                ];
+            }
+        };
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: new CallableConsumer($handler, []),
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        $this->assertTrue($handlerCalled);
+        $this->assertTrue($consumerProvided);
+        $this->assertEquals('test-topic', $messageData['topic']);
+        $this->assertEquals(1, $messageData['partition']);
+        $this->assertEquals(5, $messageData['offset']);
+        $this->assertTrue($messageData['has_consumer']);
+        $this->assertTrue($messageData['can_commit']);
+    }
+
+    #[Test]
+    public function it_allows_handler_classes_to_commit_manually(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 3;
+        $message->partition = 2;
+        $message->headers = [];
+
+        $commitCalled = false;
+        $commitParams = null;
+
+        // Mock the committer to track manual commits
+        $customCommitter = new class($commitCalled, $commitParams) implements \Junges\Kafka\Contracts\Committer {
+            public function __construct(private bool &$commitCalledRef, private mixed &$commitParamsRef)
+            {
+            }
+
+            public function commitMessage(\RdKafka\Message $message, bool $success): void
+            {
+                // Not called for manual commits
+            }
+
+            public function commitDlq(\RdKafka\Message $message): void
+            {
+                // Not relevant for this test
+            }
+
+            public function commit(mixed $messageOrOffsets = null): void
+            {
+                $this->commitCalledRef = true;
+                $this->commitParamsRef = $messageOrOffsets;
+            }
+
+            public function commitAsync(mixed $messageOrOffsets = null): void
+            {
+                // Not used in this test
+            }
+        };
+
+        $customCommitterFactory = new class($customCommitter) implements \Junges\Kafka\Contracts\CommitterFactory {
+            public function __construct(private \Junges\Kafka\Contracts\Committer $committer)
+            {
+            }
+
+            public function make(KafkaConsumer $kafkaConsumer, Config $config): \Junges\Kafka\Contracts\Committer
+            {
+                return $this->committer;
+            }
+        };
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $handlerCalled = false;
+
+        $handler = new class($handlerCalled) implements Handler {
+            public function __construct(private bool &$handlerCalledRef)
+            {
+            }
+
+            public function __invoke(ConsumerMessage $message, MessageConsumer $consumer): void
+            {
+                $this->handlerCalledRef = true;
+                // Manually commit using the consumer parameter - just like closures!
+                $consumer->commit($message);
+            }
+        };
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: new CallableConsumer($handler, []),
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer(), $customCommitterFactory);
+        $consumer->consume();
+
+        $this->assertTrue($handlerCalled);
+        $this->assertTrue($commitCalled);
+        $this->assertInstanceOf(ConsumerMessage::class, $commitParams);
+        $this->assertEquals('test-topic', $commitParams->getTopicName());
+        $this->assertEquals(2, $commitParams->getPartition());
+        $this->assertEquals(3, $commitParams->getOffset());
     }
 }

--- a/tests/Consumers/ManualCommitTest.php
+++ b/tests/Consumers/ManualCommitTest.php
@@ -1,0 +1,766 @@
+<?php declare(strict_types=1);
+
+namespace Junges\Kafka\Tests\Consumers;
+
+use Junges\Kafka\Config\Config;
+use Junges\Kafka\Consumers\CallableConsumer;
+use Junges\Kafka\Consumers\Consumer;
+use Junges\Kafka\Contracts\ConsumerMessage;
+use Junges\Kafka\Message\ConsumedMessage;
+use Junges\Kafka\Message\Deserializers\JsonDeserializer;
+use Junges\Kafka\Tests\LaravelKafkaTestCase;
+use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
+use RdKafka\KafkaConsumer;
+use RdKafka\Message;
+use RdKafka\TopicPartition;
+
+final class ManualCommitTest extends LaravelKafkaTestCase
+{
+    #[Test]
+    public function it_can_commit_manually_with_consumer_message(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 5;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $commitCalled = false;
+        $committedOffsets = [];
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commit')
+            ->with(m::on(function($topicPartitions) use (&$commitCalled, &$committedOffsets) {
+                $commitCalled = true;
+                if (is_array($topicPartitions) && count($topicPartitions) === 1) {
+                    $tp = $topicPartitions[0];
+                    if ($tp instanceof TopicPartition) {
+                        $committedOffsets = [
+                            'topic' => $tp->getTopic(),
+                            'partition' => $tp->getPartition(),
+                            'offset' => $tp->getOffset()
+                        ];
+                        return true;
+                    }
+                }
+                return false;
+            }))
+            ->andReturn()
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $handlerCalled = false;
+        $manualCommitCalled = false;
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) use (&$handlerCalled, &$manualCommitCalled) {
+                $handlerCalled = true;
+                $consumer->commit($message);
+                $manualCommitCalled = true;
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        $this->assertTrue($handlerCalled);
+        $this->assertTrue($manualCommitCalled);
+        $this->assertTrue($commitCalled);
+        $this->assertEquals('test-topic', $committedOffsets['topic']);
+        $this->assertEquals(1, $committedOffsets['partition']);
+        $this->assertEquals(6, $committedOffsets['offset']); // offset + 1
+    }
+
+    #[Test] 
+    public function it_can_commit_async_with_consumer_message(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 10;
+        $message->partition = 2;
+        $message->headers = [];
+
+        $commitAsyncCalled = false;
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commitAsync')
+            ->with(m::on(function($topicPartitions) use (&$commitAsyncCalled) {
+                $commitAsyncCalled = true;
+                return is_array($topicPartitions) && count($topicPartitions) === 1 
+                    && $topicPartitions[0] instanceof TopicPartition;
+            }))
+            ->andReturn()
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) {
+                $consumer->commitAsync($message);
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        $this->assertTrue($commitAsyncCalled);
+    }
+
+    #[Test]
+    public function it_can_commit_without_parameters(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 0;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $commitCalled = false;
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commit')
+            ->with(null)
+            ->andReturnUsing(function() use (&$commitCalled) {
+                $commitCalled = true;
+                return null;
+            })
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) {
+                // Commit all current assignment offsets
+                $consumer->commit();
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        $this->assertTrue($commitCalled);
+    }
+
+    #[Test]
+    public function it_can_commit_with_rdkafka_message(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 0;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $commitCalled = false;
+        $committedMessage = null;
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commit')
+            ->with(m::on(function($msg) use (&$commitCalled, &$committedMessage, $message) {
+                $commitCalled = true;
+                $committedMessage = $msg;
+                return $msg === $message;
+            }))
+            ->andReturn()
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) {
+                $rdkafkaMessage = new Message();
+                $rdkafkaMessage->topic_name = $message->getTopicName();
+                $rdkafkaMessage->partition = $message->getPartition();
+                $rdkafkaMessage->offset = $message->getOffset();
+                
+                $consumer->commit($rdkafkaMessage);
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        $this->assertTrue($commitCalled);
+        $this->assertInstanceOf(Message::class, $committedMessage);
+    }
+
+    #[Test]
+    public function it_does_not_auto_commit_when_manual_commit_is_enabled(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 0;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commit')
+            ->never() // Should never be called for auto-commit
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) {
+                // Process message but don't commit, with manual commit disabled, no auto-commit should happen
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+    }
+
+    #[Test]
+    public function it_converts_consumer_message_to_topic_partition_correctly(): void
+    {
+        $consumerMessage = new ConsumedMessage(
+            topicName: 'test-topic',
+            partition: 3,
+            headers: [],
+            body: 'test message',
+            key: 'test-key',
+            offset: 15,
+            timestamp: time()
+        );
+
+        $commitCalled = false;
+        $topicPartitionData = [];
+
+        $dummyMessage = new Message();
+        $dummyMessage->err = 0;
+        $dummyMessage->topic_name = 'test-topic';
+        $dummyMessage->partition = 1;
+        $dummyMessage->offset = 0;
+        $dummyMessage->payload = '{}';
+        $dummyMessage->headers = [];
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($dummyMessage)
+            ->shouldReceive('commit')
+            ->with(m::on(function($topicPartitions) use (&$commitCalled, &$topicPartitionData) {
+                $commitCalled = true;
+                if (is_array($topicPartitions) && count($topicPartitions) === 1) {
+                    $tp = $topicPartitions[0];
+                    if ($tp instanceof TopicPartition) {
+                        $topicPartitionData = [
+                            'topic' => $tp->getTopic(),
+                            'partition' => $tp->getPartition(),
+                            'offset' => $tp->getOffset()
+                        ];
+                        return true;
+                    }
+                }
+                return false;
+            }))
+            ->andReturn()
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) use ($consumerMessage) {
+                // Use the specific ConsumerMessage for commit
+                $consumer->commit($consumerMessage);
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        $this->assertTrue($commitCalled);
+        $this->assertEquals('test-topic', $topicPartitionData['topic']);
+        $this->assertEquals(3, $topicPartitionData['partition']);
+        $this->assertEquals(16, $topicPartitionData['offset']);
+    }
+
+    #[Test]
+    public function it_handles_commit_errors_gracefully(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 0;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $exceptionThrown = false;
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commit')
+            ->andThrow(new \RdKafka\Exception('Commit failed', RD_KAFKA_RESP_ERR_INVALID_CONFIG))
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) use (&$exceptionThrown) {
+                try {
+                    $consumer->commit($message);
+                } catch (\Throwable $e) {
+                    $exceptionThrown = true;
+                }
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        $this->assertTrue($exceptionThrown);
+    }
+
+    #[Test]
+    public function it_ignores_no_offset_commit_errors(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 0;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $noExceptionThrown = true;
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commit')
+            ->andThrow(new \RdKafka\Exception('No offset', RD_KAFKA_RESP_ERR__NO_OFFSET))
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) use (&$noExceptionThrown) {
+                try {
+                    $consumer->commit($message);
+                } catch (\RdKafka\Exception $e) {
+                    $noExceptionThrown = false;
+                }
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        // RD_KAFKA_RESP_ERR__NO_OFFSET errors should be ignored
+        $this->assertTrue($noExceptionThrown);
+    }
+
+    #[Test]
+    public function it_auto_commits_when_auto_commit_is_enabled(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 0;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $autoCommitCalled = false;
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commit')
+            ->with($message) // Auto-commit should pass the original message
+            ->andReturnUsing(function() use (&$autoCommitCalled) {
+                $autoCommitCalled = true;
+                return null;
+            })
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $handlerCalled = false;
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) use (&$handlerCalled) {
+                $handlerCalled = true;
+                // Don't manually commit, auto-commit should handle it
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: true
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        $this->assertTrue($handlerCalled);
+        $this->assertTrue($autoCommitCalled);
+    }
+
+    #[Test]
+    public function it_allows_manual_commit_to_override_auto_commit_behavior(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 5;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $manualCommitCalled = false;
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commit')
+            ->with(m::type('array')) // Manual commit converts to TopicPartition array
+            ->andReturnUsing(function() use (&$manualCommitCalled) {
+                $manualCommitCalled = true;
+                return null;
+            })
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        $handlerCalled = false;
+
+        $fakeHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) use (&$handlerCalled) {
+                $handlerCalled = true;
+                $consumer->commit($message);
+            },
+            []
+        );
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer());
+        $consumer->consume();
+
+        $this->assertTrue($handlerCalled);
+        $this->assertTrue($manualCommitCalled);
+    }
+
+    #[Test]
+    public function it_handles_handler_exceptions_differently_in_auto_vs_manual_commit(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 0;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $mockedKafkaConsumerManualCommit = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message)
+            ->shouldReceive('commit')
+            ->never() // Should not commit on exception in manual mode
+            ->shouldReceive('commitAsync')
+            ->never()
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumerManualCommit);
+        $this->mockProducer();
+
+        $manualCommitHandlerCalled = false;
+
+        $fakeHandlerManualCommit = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) use (&$manualCommitHandlerCalled) {
+                $manualCommitHandlerCalled = true;
+                throw new \Exception('Processing failed');
+            },
+            []
+        );
+
+        $manualCommitConfig = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandlerManualCommit,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $manualCommitConsumer = new Consumer($manualCommitConfig, new JsonDeserializer());
+
+        try {
+            $manualCommitConsumer->consume();
+        } catch (\Exception) {
+        }
+
+        $this->assertTrue($manualCommitHandlerCalled);
+    }
+
+    #[Test]
+    public function it_uses_same_commit_infrastructure_for_both_modes(): void
+    {
+        $message = new Message();
+        $message->err = 0;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 7;
+        $message->partition = 2;
+        $message->headers = [];
+
+        $commitCallsLog = [];
+
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturn($message, $message)
+            ->shouldReceive('commit')
+            ->andReturnUsing(function($params) use (&$commitCallsLog) {
+                $commitCallsLog[] = [
+                    'type' => 'commit',
+                    'params' => $params
+                ];
+                return null;
+            })
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn() => $mockedKafkaConsumer);
+        $this->mockProducer();
+
+        // Test 1: Auto-commit mode
+        $autoCommitHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) {
+                // Just process, auto-commit will handle it
+            },
+            []
+        );
+
+        $autoCommitConfig = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $autoCommitHandler,
+            maxMessages: 1,
+            autoCommit: true
+        );
+
+        $autoCommitConsumer = new Consumer($autoCommitConfig, new JsonDeserializer());
+        $autoCommitConsumer->consume();
+
+        $manualCommitHandler = new CallableConsumer(
+            function (ConsumerMessage $message, Consumer $consumer) {
+                $consumer->commit($message);
+            },
+            []
+        );
+
+        $manualCommitConfig = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $manualCommitHandler,
+            maxMessages: 1,
+            autoCommit: false
+        );
+
+        $manualCommitConsumer = new Consumer($manualCommitConfig, new JsonDeserializer());
+        $manualCommitConsumer->consume();
+
+        $this->assertCount(2, $commitCallsLog);
+        $this->assertInstanceOf(Message::class, $commitCallsLog[0]['params']);
+        $this->assertIsArray($commitCallsLog[1]['params']);
+    }
+}

--- a/tests/Consumers/SimpleQueueableHandler.php
+++ b/tests/Consumers/SimpleQueueableHandler.php
@@ -5,10 +5,11 @@ namespace Junges\Kafka\Tests\Consumers;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Junges\Kafka\Contracts\ConsumerMessage;
 use Junges\Kafka\Contracts\Handler;
+use Junges\Kafka\Contracts\MessageConsumer;
 
 final class SimpleQueueableHandler implements Handler, ShouldQueue
 {
-    public function __invoke(ConsumerMessage $message): void
+    public function __invoke(ConsumerMessage $message, MessageConsumer $consumer): void
     {
         //
     }

--- a/tests/FailingCommitter.php
+++ b/tests/FailingCommitter.php
@@ -26,7 +26,7 @@ final class FailingCommitter implements Committer
     public function commitMessage(Message $message = null, bool $success = null): void
     {
         $this->timesTriedToCommitMessage++;
-        $this->commit();
+        $this->doCommit();
     }
 
     /**
@@ -35,23 +35,7 @@ final class FailingCommitter implements Committer
     public function commitDlq(Message $message): void
     {
         $this->timesTriedToCommitDlq++;
-        $this->commit();
-    }
-
-    /**
-     * @throws \Exception
-     */
-    private function commit(): void
-    {
-        $this->commitCount++;
-
-        if ($this->commitCount > $this->timesToFail) {
-            $this->commitCount = 0;
-
-            return;
-        }
-
-        throw $this->failure;
+        $this->doCommit();
     }
 
     public function getTimesTriedToCommitMessage(): int
@@ -62,5 +46,37 @@ final class FailingCommitter implements Committer
     public function getTimesTriedToCommitDlq(): int
     {
         return $this->timesTriedToCommitDlq;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function commit(mixed $messageOrOffsets = null): void
+    {
+        $this->doCommit();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function commitAsync(mixed $messageOrOffsets = null): void
+    {
+        $this->doCommit();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function doCommit(): void
+    {
+        $this->commitCount++;
+
+        if ($this->commitCount > $this->timesToFail) {
+            $this->commitCount = 0;
+
+            return;
+        }
+
+        throw $this->failure;
     }
 }


### PR DESCRIPTION
## Problem

 This package supports manual commits (in theory), but the code for actually doing it was removed in prior versions. Since I had no tests in place, it took a long time notice & then fix it. Unless using auto-commit, message handlers had no way to manually commit messages. This created a  critical gap where users could disable auto-commit but couldn't control when offsets were committed, leading to:

  - Messages never being committed (processed repeatedly on restart)
  - No control over commit timing for error handling
  - Inability to implement at-least-once delivery guarantees

## Solution

Implemented comprehensive manual commit support by extending the handler interface and consumer infrastructure to provide full commit control to message handlers.

  - Full Commit API: Both sync (commit()) and async (commitAsync()) methods
  - Flexible Parameters: Support for message objects, TopicPartitions, or null (current offsets)
  - Custom Committer Support: Works with existing custom committers

## Breaking Changes

The handler interface had to be update to include the message consumer as a second parameter. This is primarily related to the manual commit.

**Before**
```php
public function __invoke(ConsumerMessage $message): void
```
**After**
```php
public function __invoke(ConsumerMessage $message, MessageConsumer $consumer): void
```

## Usage Examples

### Closure Handler
```php
$consumer = Kafka::consumer(['orders'])
    ->withManualCommit()
    ->withHandler(function(ConsumerMessage $message, MessageConsumer $consumer) {
        try {
            processOrder($message->getBody());
            $consumer->commit($message);
        } catch (Exception $e) {
            Log::error('Processing failed', ['error' => $e->getMessage()]);
        }
    });
```
### Handler Class
```php
class OrderHandler implements Handler
{     
    public function __invoke(ConsumerMessage $message, MessageConsumer $consumer): void
    {
        try {
             $this->processOrder($message);
             $consumer->commit($message); 
        } catch (ValidationException $e) {
            Log::warning('Invalid order', ['error' => $e->getMessage()]);
        }
    }
}
```

## Migration Guide

 ### For Closure Handlers

  No changes required. The consumer parameter is automatically provided:
```php
  // This continues to work
  $consumer->withHandler(function($message) {
      // Original handlers work unchanged
  });
```

```php
// Now you can also use manual commits
$consumer->withHandler(function($message, $consumer) {
     // Manual commit control available
     $consumer->commit($message);
});
```
### For Handler Classes

Update your Handler classes to accept the consumer parameter:
```php
// Before
class MyHandler implements Handler {
    public function __invoke(ConsumerMessage $message): void {
        // Process message here...
    }
}
```
```php
// After  
class MyHandler implements Handler {
    public function __invoke(ConsumerMessage $message, MessageConsumer $consumer): void {
        // Process message here...
        $consumer->commit($message);
    }
}
```