### PR TITLE
Add helper for changing rebalancing strategy for consumer groups

### DIFF
--- a/docs/consuming-messages/consumer-groups.md
+++ b/docs/consuming-messages/consumer-groups.md
@@ -24,3 +24,63 @@ Watch how Kafka automatically redistributes partitions among consumers when the 
 ```+parse
 <x-docs.animation.rebalance />
 ```
+
+### Partition Assignment Strategies
+
+You can configure how Kafka assigns partitions to consumers in your consumer group by specifying a rebalance strategy:
+
+```php
+use Junges\Kafka\Facades\Kafka;
+use Junges\Kafka\Config\RebalanceStrategy;
+
+$consumer = Kafka::consumer()
+    ->withConsumerGroupId('my-group')
+    ->withRebalanceStrategy(RebalanceStrategy::ROUND_ROBIN);
+```
+
+#### Available Strategies
+
+- **Range** (`RebalanceStrategy::RANGE`): Default strategy. Assigns partitions on a per-topic basis by dividing partitions evenly among consumers.
+- **Round Robin** (`RebalanceStrategy::ROUND_ROBIN`): Distributes partitions evenly across all consumers in a round-robin fashion.
+- **Sticky** (`RebalanceStrategy::STICKY`): Maintains balanced assignments while preserving existing assignments during rebalancing.
+- **Cooperative Sticky** (`RebalanceStrategy::COOPERATIVE_STICKY`): Same as sticky but allows cooperative rebalancing for reduced downtime.
+
+#### Examples
+
+```php
+// Using Range strategy (default)
+$consumer = Kafka::consumer()
+    ->withConsumerGroupId('my-group')
+    ->withRebalanceStrategy(RebalanceStrategy::RANGE);
+
+// Using Round Robin for better distribution
+$consumer = Kafka::consumer()
+    ->withConsumerGroupId('my-group')
+    ->withRebalanceStrategy(RebalanceStrategy::ROUND_ROBIN);
+
+// Using Sticky for minimal disruption during rebalancing
+$consumer = Kafka::consumer()
+    ->withConsumerGroupId('my-group')
+    ->withRebalanceStrategy(RebalanceStrategy::STICKY);
+
+// Using Cooperative Sticky for minimal downtime
+$consumer = Kafka::consumer()
+    ->withConsumerGroupId('my-group')
+    ->withRebalanceStrategy(RebalanceStrategy::COOPERATIVE_STICKY);
+```
+
+You can also pass strategy names as strings:
+
+```php
+$consumer = Kafka::consumer()
+    ->withConsumerGroupId('my-group')
+    ->withRebalanceStrategy('sticky');
+```
+
+Or set the strategy using raw options:
+
+```php
+$consumer = Kafka::consumer()
+    ->withConsumerGroupId('my-group')
+    ->withOption('partition.assignment.strategy', 'sticky');
+```

--- a/src/Config/RebalanceStrategy.php
+++ b/src/Config/RebalanceStrategy.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Junges\Kafka\Config;
+
+enum RebalanceStrategy: string
+{
+    /**
+     * The range assignor works on a per-topic basis. For each topic, it lays out the available partitions in numeric order
+     * and the consumer threads in lexicographic order. It then divides the number of partitions by the total number of
+     * consumer streams (threads) to determine the number of partitions to assign to each consumer.
+     */
+    case RANGE = 'range';
+
+    /**
+     * The round-robin assignor lays out all the available partitions and all the available consumer threads.
+     * It then proceeds to do a round-robin assignment from partition to consumer thread.
+     */
+    case ROUND_ROBIN = 'roundrobin';
+
+    /**
+     * The sticky assignor serves two purposes. First, it guarantees an assignment that is as balanced as possible.
+     * Second, it preserves as many existing assignment as possible when a reassignment occurs.
+     */
+    case STICKY = 'sticky';
+
+    /**
+     * The cooperative sticky assignor is identical to the sticky assignor but allows for cooperative rebalancing.
+     */
+    case COOPERATIVE_STICKY = 'cooperative-sticky';
+
+    /** @return array<string> */
+    public static function values(): array
+    {
+        return array_map(fn (self $case) => $case->value, self::cases());
+    }
+}

--- a/src/Consumers/Builder.php
+++ b/src/Consumers/Builder.php
@@ -9,6 +9,7 @@ use Junges\Kafka\Concerns\InteractsWithConfigCallbacks;
 use Junges\Kafka\Config\BatchConfig;
 use Junges\Kafka\Config\Config;
 use Junges\Kafka\Config\NullBatchConfig;
+use Junges\Kafka\Config\RebalanceStrategy;
 use Junges\Kafka\Config\Sasl;
 use Junges\Kafka\Contracts\CommitterFactory;
 use Junges\Kafka\Contracts\ConsumerBuilder as ConsumerBuilderContract;
@@ -246,6 +247,24 @@ class Builder implements ConsumerBuilderContract
         $this->autoCommit = false;
 
         return $this;
+    }
+
+    /** @inheritDoc */
+    public function withRebalanceStrategy(RebalanceStrategy|string $strategy): self
+    {
+        if (is_string($strategy)) {
+            $enum = RebalanceStrategy::tryFrom($strategy);
+
+            if ($enum === null) {
+                throw new InvalidArgumentException(
+                    "Invalid rebalance strategy [{$strategy}]. Valid strategies are: " . implode(', ', RebalanceStrategy::values())
+                );
+            }
+
+            $strategy = $enum;
+        }
+
+        return $this->withOption('partition.assignment.strategy', $strategy->value);
     }
 
     /** @inheritDoc */

--- a/src/Contracts/ConsumerBuilder.php
+++ b/src/Contracts/ConsumerBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Junges\Kafka\Contracts;
 
+use Junges\Kafka\Config\RebalanceStrategy;
 use Junges\Kafka\Config\Sasl;
 
 /** @internal */
@@ -98,6 +99,9 @@ interface ConsumerBuilder extends InteractsWithConfigCallbacks
 
     /** Enables manual commit. */
     public function withManualCommit(): self;
+
+    /** Set the partition assignment (rebalance) strategy for consumer groups. */
+    public function withRebalanceStrategy(RebalanceStrategy|string $strategy): self;
 
     /** Set the configuration options. */
     public function withOptions(array $options): self;


### PR DESCRIPTION
## What's Changed

This PR introduces a user-friendly API for configuring Kafka consumer group partition assignment rebalancing strategies, making it easy for users to optimize their consumer group behavior.


- `RANGE` - Default strategy, assigns partitions per-topic
- `ROUND_ROBIN` - Distributes partitions evenly across consumers
- `STICKY` - Maintains balanced assignments while preserving existing ones
- `COOPERATIVE_STICKY` - Same as sticky but with cooperative rebalancing for reduced downtime

### Usage Examples

```php
use Junges\Kafka\Facades\Kafka;
use Junges\Kafka\Config\RebalanceStrategy;

// Modern enum approach (recommended)
$consumer = Kafka::consumer()
    ->withConsumerGroupId('my-group')
    ->withRebalanceStrategy(RebalanceStrategy::STICKY);

// String approach (also supported)
$consumer = Kafka::consumer()
    ->withConsumerGroupId('my-group')
    ->withRebalanceStrategy('cooperative-sticky');

// Existing raw option approach (unchanged)
$consumer = Kafka::consumer()
    ->withConsumerGroupId('my-group')
    ->withOption('partition.assignment.strategy', 'roundrobin');
```
