### PR TITLE
Adds a flush callback

### DIFF
--- a/src/Contracts/MessageProducer.php
+++ b/src/Contracts/MessageProducer.php
@@ -46,6 +46,9 @@ interface MessageProducer extends InteractsWithConfigCallbacks
     /** Set the message to be published. */
     public function withMessage(ProducerMessage $message): self;
 
+    /** Set a callback to be executed after flushing produced messages. */
+    public function withFlushCallback(callable $callback): self;
+
     /** Set Sasl configuration. */
     public function withSasl(string $username, string $password, string $mechanisms, string $securityProtocol = 'SASL_PLAINTEXT'): self;
 

--- a/src/Producers/Builder.php
+++ b/src/Producers/Builder.php
@@ -3,6 +3,7 @@
 namespace Junges\Kafka\Producers;
 
 use Exception;
+use Closure;
 use Illuminate\Support\Traits\Conditionable;
 use Junges\Kafka\Concerns\InteractsWithConfigCallbacks;
 use Junges\Kafka\Config\Config;
@@ -37,6 +38,8 @@ class Builder implements MessageProducer
     private ?int $flushRetries = null;
 
     private ?int $flushTimeoutInMs = null;
+
+    private ?Closure $flushCallback = null;
 
     public function __construct(
         ?string $broker = null,
@@ -116,6 +119,13 @@ class Builder implements MessageProducer
     public function withBody(mixed $body): self
     {
         $this->message->withBody($body);
+
+        return $this;
+    }
+
+    public function withFlushCallback(callable $callback): self
+    {
+        $this->flushCallback = Closure::fromCallable($callback);
 
         return $this;
     }
@@ -230,6 +240,7 @@ class Builder implements MessageProducer
             'config' => $conf,
             'serializer' => $this->serializer,
             'async' => $this->asyncProducer,
+            'flushCallback' => $this->flushCallback,
         ]);
 
         if ($this->asyncProducer) {

--- a/src/Producers/Producer.php
+++ b/src/Producers/Producer.php
@@ -2,6 +2,7 @@
 
 namespace Junges\Kafka\Producers;
 
+use Closure;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Facades\App;
@@ -27,15 +28,19 @@ class Producer implements ProducerContract
 
     private readonly Dispatcher $dispatcher;
 
+    private array $pendingMessages;
+
     public function __construct(
         private readonly Config $config,
         private readonly MessageSerializer $serializer,
         private readonly bool $async = false,
+        private readonly ?Closure $flushCallback = null,
     ) {
         $this->producer = app(KafkaProducer::class, [
             'conf' => $this->getConf($this->config->getProducerOptions()),
         ]);
         $this->dispatcher = App::make(Dispatcher::class);
+        $this->pendingMessages = [];
     }
 
     public function __destruct()
@@ -57,6 +62,8 @@ class Producer implements ProducerContract
         $message = $this->serializer->serialize($message);
 
         $this->produceMessage($topic, $message);
+
+        $this->pendingMessages[] = $message;
 
         $this->producer->poll(0);
 
@@ -85,6 +92,8 @@ class Producer implements ProducerContract
                     $result = $this->producer->flush($timeout);
 
                     if ($result === RD_KAFKA_RESP_ERR_NO_ERROR) {
+                        $this->runFlushCallback();
+
                         return true;
                     }
 
@@ -133,5 +142,15 @@ class Producer implements ProducerContract
         );
 
         $this->dispatcher->dispatch(new MessagePublished($message));
+    }
+
+    private function runFlushCallback(): void
+    {
+        if ($this->flushCallback === null || $this->pendingMessages === []) {
+            return;
+        }
+
+        ($this->flushCallback)($this->pendingMessages);
+        $this->pendingMessages = [];
     }
 }

--- a/src/Support/Testing/Fakes/KafkaFake.php
+++ b/src/Support/Testing/Fakes/KafkaFake.php
@@ -131,8 +131,12 @@ class KafkaFake
     private function makeProducerBuilderFake(?string $broker = null): ProducerBuilderFake
     {
         return (new ProducerBuilderFake(broker: $broker))
-            ->withProducerCallback(
-                fn (Message $message) => $this->publishedMessages[] = $message
+            ->withFlushCallback(
+                function (array $messages): void {
+                    foreach ($messages as $message) {
+                        $this->publishedMessages[] = $message;
+                    }
+                }
             );
     }
 

--- a/src/Support/Testing/Fakes/ProducerBuilderFake.php
+++ b/src/Support/Testing/Fakes/ProducerBuilderFake.php
@@ -25,7 +25,7 @@ class ProducerBuilderFake implements MessageProducer
 
     private string $topic = '';
 
-    private ?Closure $producerCallback = null;
+    private ?Closure $flushCallback = null;
 
     private ?int $flushRetries = null;
 
@@ -59,9 +59,9 @@ class ProducerBuilderFake implements MessageProducer
         return $this;
     }
 
-    public function withProducerCallback(callable $callback): self
+    public function withFlushCallback(callable $callback): self
     {
-        $this->producerCallback = $callback;
+        $this->flushCallback = Closure::fromCallable($callback);
 
         return $this;
     }
@@ -222,8 +222,8 @@ class ProducerBuilderFake implements MessageProducer
             'config' => $config,
         ]);
 
-        if ($this->producerCallback) {
-            $producerFake->withProduceCallback($this->producerCallback);
+        if ($this->flushCallback) {
+            $producerFake->withFlushCallback($this->flushCallback);
         }
 
         return $producerFake;

--- a/src/Support/Testing/Fakes/ProducerFake.php
+++ b/src/Support/Testing/Fakes/ProducerFake.php
@@ -13,7 +13,9 @@ class ProducerFake implements Producer
 {
     use ManagesTransactions;
 
-    private ?Closure $producerCallback = null;
+    private ?Closure $flushCallback = null;
+
+    private array $pendingMessages = [];
 
     public function __construct(
         private readonly Config $config,
@@ -24,25 +26,29 @@ class ProducerFake implements Producer
         return new Conf;
     }
 
-    public function withProduceCallback(callable $callback): self
+    public function withFlushCallback(callable $callback): self
     {
-        $this->producerCallback = $callback;
+        $this->flushCallback = Closure::fromCallable($callback);
 
         return $this;
     }
 
     public function produce(ProducerMessage $message): bool
     {
-        if ($this->producerCallback !== null) {
-            $callback = $this->producerCallback;
-            $callback($message);
-        }
+        $this->pendingMessages[] = $message;
+
+        $this->flush();
 
         return true;
     }
 
     public function flush(): int
     {
+        if ($this->flushCallback !== null && $this->pendingMessages !== []) {
+            ($this->flushCallback)($this->pendingMessages);
+            $this->pendingMessages = [];
+        }
+
         return 1;
     }
 }

--- a/tests/Producers/ProducerTest.php
+++ b/tests/Producers/ProducerTest.php
@@ -3,6 +3,7 @@
 namespace Junges\Kafka\Tests\Producers;
 
 use Junges\Kafka\Config\Config;
+use Junges\Kafka\Contracts\ProducerMessage;
 use Junges\Kafka\Message\Message;
 use Junges\Kafka\Message\Serializers\JsonSerializer;
 use Junges\Kafka\Producers\Producer;
@@ -26,5 +27,36 @@ final class ProducerTest extends LaravelKafkaTestCase
         $producer->produce($message);
 
         $this->assertSame($payload, $message->getBody());
+    }
+
+    #[Test]
+    public function it_calls_callback_after_flushing_messages(): void
+    {
+        $this->mockKafkaProducer();
+        $callbackCalls = 0;
+        $receivedMessages = [];
+
+        $producer = new Producer(
+            new Config('broker', ['test-topic']),
+            new JsonSerializer,
+            false,
+            function (array $messages) use (&$callbackCalls, &$receivedMessages) {
+                $callbackCalls++;
+                $receivedMessages = $messages;
+            }
+        );
+
+        $message = new Message(
+            body: ['key' => 'value'],
+        );
+        $message->onTopic('test-topic');
+
+        $producer->produce($message);
+
+        $this->assertSame(1, $callbackCalls);
+        $this->assertCount(1, $receivedMessages);
+        $this->assertInstanceOf(ProducerMessage::class, $receivedMessages[0]);
+        $this->assertSame('test-topic', $receivedMessages[0]->getTopicName());
+        $this->assertSame(['key' => 'value'], json_decode((string) $receivedMessages[0]->getBody(), true));
     }
 }


### PR DESCRIPTION
###  Add flush callback for async producers                                                                                                                                                                                           
                                                                                                                                                                                                                                   
 This PR adds a `withFlushCallback()` method that allows registering a callback to be executed after messages are successfully flushed to Kafka.                                                                                            

```php                                                                                                                                                                                                                                   
  Kafka::publish('broker')                                                                                                                                                                                                         
      ->onTopic('topic')                                                                                                                                                                                                           
      ->withMessage($message)                                                                                                                                                                                                      
      ->withFlushCallback(function (array $messages) {                                                                                                                                                                             
          // Update database records, mark as sent, etc.                                                                                                                                                                           
      })                                                                                                                                                                                                                           
      ->send();                                                                                                                                                                                                                    
```                                                                                                                                                                                                                                   

The callback receives an array of all messages that were flushed, enabling batch operations like updating multiple Outbox records in a single query. This is useful for implementing the Outbox pattern where you need confirmation that messages were actually delivered before updating database state.  