### PR TITLE
Add RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART to retryable consumer errors

### DIFF
--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -39,6 +39,7 @@ class Consumer implements MessageConsumer
         RD_KAFKA_RESP_ERR__TRANSPORT,
         RD_KAFKA_RESP_ERR_REQUEST_TIMED_OUT,
         RD_KAFKA_RESP_ERR__TIMED_OUT,
+        RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART,
     ];
 
     private const CONSUME_STOP_EOF_ERRORS = [


### PR DESCRIPTION
### Summary

- When `allow.auto.create.topics` is set to `true`, the Kafka broker creates the topic asynchronously upon the consumer's first metadata request. During the brief window before the topic is fully available, `consume()` returns
  messages with error code 3 (`RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART`), causing the consumer to throw a ConsumerException and crash.
- This PR adds `RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART` to the `IGNORABLE_CONSUMER_ERRORS` list in `Consumer.php`, allowing the consume loop to continue polling until the topic becomes available.


The `handleMessage()` method checks incoming messages against `IGNORABLE_CONSUMER_ERRORS`. Errors in this list are silently skipped, allowing the consume loop to continue. `RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART` is a transient error in this context (same category as transport errors and timeouts, which are already ignored), so adding it to this list lets the consumer keep polling until the topic is ready.

This should fix #374
