### PR TITLE
Drop Laravel 10/11 support, add PHP 8.5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,14 +10,10 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.4, 8.3, 8.2]
-        laravel: ['10.*', '11.*', '12.*', '13.*']
+        php: [8.5, 8.4, 8.3, 8.2]
+        laravel: ['12.*', '13.*']
         dependency-version: [prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-          - laravel: 11.*
-            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 13.*

--- a/composer.json
+++ b/composer.json
@@ -3,17 +3,17 @@
     "description": "A kafka driver for laravel",
     "type": "library",
     "require": {
-        "php": "^8.2|^8.3|^8.4",
+        "php": "^8.2|^8.3|^8.4|^8.5",
         "ext-rdkafka": "^6.0",
         "monolog/monolog": "^3",
         "mateusjunges/avro-serde-php": "^3.0",
-        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0"
+        "illuminate/support": "^12.0|^13.0",
+        "illuminate/contracts": "^12.0|^13.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^10.5|^11.5.3|^12.5.12",
-        "orchestra/testbench": "^7.16|^8.0|^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "predis/predis": "^1|^3.4",
         "rector/rector": "^0.19.8|^2.3",
         "laravel/pint": "dev-main"


### PR DESCRIPTION
This pull request updates the package to support newer versions of PHP and Laravel, while dropping support for older Laravel and Testbench versions.