### PR TITLE
Add support for OAUTHBEARER token refresh callback

### DIFF
--- a/docs/advanced-usage/sasl-authentication.md
+++ b/docs/advanced-usage/sasl-authentication.md
@@ -38,6 +38,38 @@ $consumer = \Junges\Kafka\Facades\Kafka::consumer()
 </x-docs.tip>
 ```
 
+### OAUTHBEARER Authentication
+
+If your Kafka cluster requires OAuth 2.0 / OAUTHBEARER authentication (common with Confluent Cloud, AWS MSK with IAM, or enterprise deployments), you can use the `withOAuthBearerTokenRefreshCallback` method. This registers a callback that librdkafka invokes whenever it needs a fresh token.
+
+```php
+use Junges\Kafka\Facades\Kafka;
+
+$consumer = Kafka::consumer(['my.topic'])
+    ->withOptions([
+        'security.protocol' => 'SASL_SSL',
+        'sasl.mechanisms'   => 'OAUTHBEARER',
+    ])
+    ->withOAuthBearerTokenRefreshCallback(function ($consumer, string $oauthConfig): void {
+        $token      = fetchTokenFromIdP();
+        $expiresMs  = getTokenExpiryMs($token);
+        $principal   = 'my-client-id';
+        $extensions = [
+            'logicalCluster' => 'lkc-xxxxx',
+            'identityPoolId' => 'pool-xxxxx',
+        ];
+
+        $consumer->oauthbearerSetToken($token, $expiresMs, $principal, $extensions);
+    })
+    ->withHandler(new MyMessageHandler())
+    ->build()
+    ->consume();
+```
+
+The callback receives two arguments: the `RdKafka\KafkaConsumer` (or `RdKafka\Producer`) instance and the `oauthbearer_config` string from your librdkafka configuration. Inside the callback, call `$consumer->oauthbearerSetToken()` to provide the token, or `$consumer->oauthbearerSetTokenFailure($reason)` if the token could not be obtained.
+
+This method is available on both the consumer and producer builders.
+
 ### TLS Authentication
 
 For using TLS authentication with Laravel Kafka you can configure your client using the following options:

--- a/src/Concerns/InteractsWithConfigCallbacks.php
+++ b/src/Concerns/InteractsWithConfigCallbacks.php
@@ -61,4 +61,12 @@ trait InteractsWithConfigCallbacks
 
         return $this;
     }
+
+    /** Set the OAUTHBEARER token refresh callback. */
+    public function withOAuthBearerTokenRefreshCallback(callable $callback): self
+    {
+        $this->callbacks['setOauthbearerTokenRefreshCb'] = $callback;
+
+        return $this;
+    }
 }

--- a/src/Contracts/InteractsWithConfigCallbacks.php
+++ b/src/Contracts/InteractsWithConfigCallbacks.php
@@ -15,4 +15,7 @@ interface InteractsWithConfigCallbacks
 
     /** Set the log callback. */
     public function withLogCb(callable $callback): self;
+
+    /** Set the OAUTHBEARER token refresh callback. */
+    public function withOAuthBearerTokenRefreshCallback(callable $callback): self;
 }

--- a/tests/Consumers/ConsumerBuilderTest.php
+++ b/tests/Consumers/ConsumerBuilderTest.php
@@ -438,6 +438,21 @@ final class ConsumerBuilderTest extends LaravelKafkaTestCase
         $this->assertArrayHasKey('setRebalanceCb', $callbacks);
         $this->assertIsCallable($callbacks['setRebalanceCb']);
     }
+
+    #[Test]
+    public function it_can_set_oauth_bearer_token_refresh_callback(): void
+    {
+        $consumer = Builder::create('broker', ['test-topic'], 'group')
+            ->withOAuthBearerTokenRefreshCallback(function ($consumer, string $oauthConfig): void {
+                // Token refresh logic
+            });
+
+        $this->assertInstanceOf(Consumer::class, $consumer->build());
+
+        $callbacks = $this->getPropertyWithReflection('callbacks', $consumer);
+        $this->assertArrayHasKey('setOauthbearerTokenRefreshCb', $callbacks);
+        $this->assertIsCallable($callbacks['setOauthbearerTokenRefreshCb']);
+    }
 }
 
 final class TestMiddleware


### PR DESCRIPTION
## Summary

- Add `withOAuthBearerTokenRefreshCallback(callable $callback)` method to the `InteractsWithConfigCallbacks` trait and contract, enabling OAUTHBEARER authentication for consumers and producers
- The callback is registered on `RdKafka\Conf` via `setOauthbearerTokenRefreshCb()`, which librdkafka invokes whenever it needs a fresh token
- Add documentation for OAUTHBEARER authentication in the SASL authentication docs

Closes #383