### PR TITLE
Clear pending messages when no callback defined

### DIFF
--- a/src/Producers/Producer.php
+++ b/src/Producers/Producer.php
@@ -146,11 +146,14 @@ class Producer implements ProducerContract
 
     private function runFlushCallback(): void
     {
-        if ($this->flushCallback === null || $this->pendingMessages === []) {
+        if ($this->pendingMessages === []) {
             return;
         }
 
-        ($this->flushCallback)($this->pendingMessages);
+        if ($this->flushCallback !== null) {
+            ($this->flushCallback)($this->pendingMessages);
+        }
+
         $this->pendingMessages = [];
     }
 }

--- a/src/Producers/Producer.php
+++ b/src/Producers/Producer.php
@@ -63,7 +63,9 @@ class Producer implements ProducerContract
 
         $this->produceMessage($topic, $message);
 
-        $this->pendingMessages[] = $message;
+        if ($this->flushCallback) {
+            $this->pendingMessages[] = $message;
+        }
 
         $this->producer->poll(0);
 

--- a/src/Support/Testing/Fakes/KafkaFake.php
+++ b/src/Support/Testing/Fakes/KafkaFake.php
@@ -131,7 +131,7 @@ class KafkaFake
     private function makeProducerBuilderFake(?string $broker = null): ProducerBuilderFake
     {
         return (new ProducerBuilderFake(broker: $broker))
-            ->withProducerCallback(
+            ->withProduceCallback(
                 fn (Message $message) => $this->publishedMessages[] = $message
             );
     }

--- a/src/Support/Testing/Fakes/KafkaFake.php
+++ b/src/Support/Testing/Fakes/KafkaFake.php
@@ -131,12 +131,8 @@ class KafkaFake
     private function makeProducerBuilderFake(?string $broker = null): ProducerBuilderFake
     {
         return (new ProducerBuilderFake(broker: $broker))
-            ->withFlushCallback(
-                function (array $messages): void {
-                    foreach ($messages as $message) {
-                        $this->publishedMessages[] = $message;
-                    }
-                }
+            ->withProducerCallback(
+                fn (Message $message) => $this->publishedMessages[] = $message
             );
     }
 

--- a/src/Support/Testing/Fakes/ProducerBuilderFake.php
+++ b/src/Support/Testing/Fakes/ProducerBuilderFake.php
@@ -25,7 +25,7 @@ class ProducerBuilderFake implements MessageProducer
 
     private string $topic = '';
 
-    private ?Closure $producerCallback = null;
+    private ?Closure $produceCallback = null;
 
     private ?Closure $flushCallback = null;
 
@@ -61,9 +61,9 @@ class ProducerBuilderFake implements MessageProducer
         return $this;
     }
 
-    public function withProducerCallback(callable $callback): self
+    public function withProduceCallback(callable $callback): self
     {
-        $this->producerCallback = $callback;
+        $this->produceCallback = Closure::fromCallable($callback);
 
         return $this;
     }
@@ -231,8 +231,8 @@ class ProducerBuilderFake implements MessageProducer
             'config' => $config,
         ]);
 
-        if ($this->producerCallback) {
-            $producerFake->withProduceCallback($this->producerCallback);
+        if ($this->produceCallback) {
+            $producerFake->withProduceCallback($this->produceCallback);
         }
 
         if ($this->flushCallback) {

--- a/src/Support/Testing/Fakes/ProducerBuilderFake.php
+++ b/src/Support/Testing/Fakes/ProducerBuilderFake.php
@@ -231,6 +231,10 @@ class ProducerBuilderFake implements MessageProducer
             'config' => $config,
         ]);
 
+        if ($this->producerCallback) {
+            $producerFake->withProduceCallback($this->producerCallback);
+        }
+
         if ($this->flushCallback) {
             $producerFake->withFlushCallback($this->flushCallback);
         }

--- a/src/Support/Testing/Fakes/ProducerBuilderFake.php
+++ b/src/Support/Testing/Fakes/ProducerBuilderFake.php
@@ -25,6 +25,8 @@ class ProducerBuilderFake implements MessageProducer
 
     private string $topic = '';
 
+    private ?Closure $producerCallback = null;
+
     private ?Closure $flushCallback = null;
 
     private ?int $flushRetries = null;
@@ -55,6 +57,13 @@ class ProducerBuilderFake implements MessageProducer
     {
         $this->topic = $topic;
         $this->message->onTopic($topic);
+
+        return $this;
+    }
+
+    public function withProducerCallback(callable $callback): self
+    {
+        $this->producerCallback = $callback;
 
         return $this;
     }

--- a/src/Support/Testing/Fakes/ProducerFake.php
+++ b/src/Support/Testing/Fakes/ProducerFake.php
@@ -13,7 +13,7 @@ class ProducerFake implements Producer
 {
     use ManagesTransactions;
 
-    private ?Closure $producerCallback = null;
+    private ?Closure $produceCallback = null;
 
     private ?Closure $flushCallback = null;
 
@@ -28,9 +28,9 @@ class ProducerFake implements Producer
         return new Conf;
     }
 
-    public function withProduceCallback(Closure $callback): self
+    public function withProduceCallback(callable $callback): self
     {
-        $this->producerCallback = $callback;
+        $this->produceCallback = Closure::fromCallable($callback);
 
         return $this;
     }
@@ -44,9 +44,8 @@ class ProducerFake implements Producer
 
     public function produce(ProducerMessage $message): bool
     {
-        if ($this->producerCallback !== null) {
-            $callback = $this->producerCallback;
-            $callback($message);
+        if ($this->produceCallback !== null) {
+            ($this->produceCallback)($message);
         }
 
         $this->pendingMessages[] = $message;
@@ -58,10 +57,11 @@ class ProducerFake implements Producer
 
     public function flush(): int
     {
-        if ($this->flushCallback !== null && $this->pendingMessages !== []) {
+        if ($this->pendingMessages !== [] && $this->flushCallback !== null) {
             ($this->flushCallback)($this->pendingMessages);
-            $this->pendingMessages = [];
         }
+
+        $this->pendingMessages = [];
 
         return 1;
     }

--- a/src/Support/Testing/Fakes/ProducerFake.php
+++ b/src/Support/Testing/Fakes/ProducerFake.php
@@ -13,6 +13,8 @@ class ProducerFake implements Producer
 {
     use ManagesTransactions;
 
+    private ?Closure $producerCallback = null;
+
     private ?Closure $flushCallback = null;
 
     private array $pendingMessages = [];
@@ -26,6 +28,13 @@ class ProducerFake implements Producer
         return new Conf;
     }
 
+    public function withProduceCallback(Closure $callback): self
+    {
+        $this->producerCallback = $callback;
+
+        return $this;
+    }
+
     public function withFlushCallback(callable $callback): self
     {
         $this->flushCallback = Closure::fromCallable($callback);
@@ -35,6 +44,11 @@ class ProducerFake implements Producer
 
     public function produce(ProducerMessage $message): bool
     {
+        if ($this->producerCallback !== null) {
+            $callback = $this->producerCallback;
+            $callback($message);
+        }
+
         $this->pendingMessages[] = $message;
 
         $this->flush();

--- a/tests/Producers/ProducerTest.php
+++ b/tests/Producers/ProducerTest.php
@@ -30,6 +30,30 @@ final class ProducerTest extends LaravelKafkaTestCase
     }
 
     #[Test]
+    public function it_does_not_leak_pending_messages_when_no_flush_callback_is_defined(): void
+    {
+        $this->mockKafkaProducer();
+
+        $producer = new Producer(
+            new Config('broker', ['test-topic']),
+            new JsonSerializer,
+        );
+
+        $message = new Message(body: ['key' => 'value']);
+        $message->onTopic('test-topic');
+
+        $producer->produce($message);
+        $producer->produce($message);
+        $producer->produce($message);
+
+        // Reflect on pendingMessages to assert it has been cleared after each flush
+        $reflection = new \ReflectionProperty(Producer::class, 'pendingMessages');
+        $reflection->setAccessible(true);
+
+        $this->assertSame([], $reflection->getValue($producer));
+    }
+
+    #[Test]
     public function it_calls_callback_after_flushing_messages(): void
     {
         $this->mockKafkaProducer();


### PR DESCRIPTION
Even though we are not using the new flush callback, we currently have to do the following when using `asyncPublish`: 
- define an empty flush callback so `flush()` clears the `pendingMessages`
- call `flush()` periodically so messages do not accumulate in memory indefinitely in long-running processes

The recently introduced flush callback feature accumulates pending messages unconditionally, but only clears the array when a flush callback is defined. This can lead to accumulating messages indefinitely when reusing the same producer instance to send a lot of messages.

The feature also relied on the flush callback for the test assertions in `KafkaFake`, which meant that any code under test that sets a flush callback would overwrite the callback necessary for asserting on published messages. 

After the fix, we are clearing the pending messages even if no flush callback is defined. We also reinstate the test-only producer callback to be able to perform assertions when flush callbacks are defined. 


Summary: 
- Only accumulate `pendingMessages` if flush callback is defined
- `runFlushCallback` clears pending messages also if flush callback is not defined (just to be safe)
- Reinstate produce callback in `KafkaFake` so flush callback can be used in tests