### PR TITLE
Stop exporting dev files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto
+
+/.github            export-ignore
+/docs               export-ignore
+/tests              export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/CHANGELOG.md       export-ignore
+/phpunit.xml        export-ignore
+/phpunit.xml.bak    export-ignore
+/pint.json          export-ignore
+/rector.php         export-ignore


### PR DESCRIPTION
I noticed that when installing this package for our project, there's a lot of dev artifacts included.

<img width="280" height="487" alt="image" src="https://github.com/user-attachments/assets/7e1b12a5-1492-4320-9818-2da9ba1d27bd" />

This should stop that from happening.