### PR TITLE
Stop consuming only after all assigned partitions reach EOF when using `stopAfterLastMessage()`

### DIFF
--- a/docs/advanced-usage/stop-consumer-after-last-message.md
+++ b/docs/advanced-usage/stop-consumer-after-last-message.md
@@ -20,6 +20,19 @@ $consumer = \Junges\Kafka\Facades\Kafka::consumer(['topic'])
 $consumer->consume();
 ```
 
+When consuming a topic with multiple partitions, the consumer stops only after all assigned partitions have been fully read. Reaching the end of a single partition does not stop the consumer while other partitions still have messages to be processed.
+
+For the consumer to detect the end of a partition as soon as it is reached, the `enable.partition.eof` option must be set to `true` in the consumer options. Without it, the consumer stops only when no message is received within the consumer timeout (defined by the `consumer_timeout_ms` configuration option).
+
+```php
+$consumer = \Junges\Kafka\Facades\Kafka::consumer(['topic'])
+    ->withConsumerGroupId('group')
+    ->withOptions(['enable.partition.eof' => 'true'])
+    ->stopAfterLastMessage()
+    ->withHandler(new Handler)
+    ->build();
+```
+
 ```+parse
 <x-sponsors.request-sponsor/>
 ```

--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -30,6 +30,7 @@ use RdKafka\Exception;
 use RdKafka\KafkaConsumer;
 use RdKafka\Message;
 use RdKafka\Producer as KafkaProducer;
+use RdKafka\TopicPartition;
 use Throwable;
 
 class Consumer implements MessageConsumer
@@ -74,6 +75,9 @@ class Consumer implements MessageConsumer
     private readonly CommitterFactory $committerFactory;
 
     private bool $stopRequested = false;
+
+    /** @var array<string, true> Partitions that have reached EOF, keyed by "topic-partition". */
+    private array $partitionsAtEof = [];
 
     private ?Closure $whenStopConsuming;
 
@@ -432,6 +436,10 @@ class Consumer implements MessageConsumer
     private function handleMessage(Message $message): void
     {
         if ($message->err === RD_KAFKA_RESP_ERR_NO_ERROR) {
+            // Receiving a message from a partition that previously reached
+            // EOF means the partition is no longer drained.
+            unset($this->partitionsAtEof[$this->partitionKey($message->topic_name, $message->partition)]);
+
             $this->messageCounter->add();
 
             $this->executeMessage($message);
@@ -440,7 +448,9 @@ class Consumer implements MessageConsumer
         }
 
         if ($this->config->shouldStopAfterLastMessage() && in_array($message->err, self::CONSUME_STOP_EOF_ERRORS, true)) {
-            $this->stopConsuming();
+            if ($message->err !== RD_KAFKA_RESP_ERR__PARTITION_EOF || $this->allAssignedPartitionsReachedEof($message)) {
+                $this->stopConsuming();
+            }
         }
 
         if (! in_array($message->err, self::IGNORABLE_CONSUMER_ERRORS, true)) {
@@ -448,6 +458,25 @@ class Consumer implements MessageConsumer
 
             throw new ConsumerException($message->errstr(), $message->err);
         }
+    }
+
+    /**
+     * Marks the partition which emitted the given EOF message as drained and
+     * checks whether all partitions currently assigned to this consumer
+     * have reached EOF, meaning there are no more messages to read.
+     */
+    private function allAssignedPartitionsReachedEof(Message $message): bool
+    {
+        $this->partitionsAtEof[$this->partitionKey($message->topic_name, $message->partition)] = true;
+
+        return collect($this->consumer->getAssignment())->every(
+            fn (TopicPartition $partition) => isset($this->partitionsAtEof[$this->partitionKey($partition->getTopic(), $partition->getPartition())])
+        );
+    }
+
+    private function partitionKey(string $topic, int $partition): string
+    {
+        return $topic.'-'.$partition;
     }
 
     private function getConsumerMessage(Message $message): ConsumerMessage

--- a/tests/Consumers/ConsumerTest.php
+++ b/tests/Consumers/ConsumerTest.php
@@ -828,6 +828,194 @@ final class ConsumerTest extends LaravelKafkaTestCase
         });
     }
 
+    #[Test]
+    public function it_stops_consuming_only_after_all_assigned_partitions_reach_eof(): void
+    {
+        $fakeHandler = new FakeHandler;
+
+        $eofPartitionZero = new Message;
+        $eofPartitionZero->err = RD_KAFKA_RESP_ERR__PARTITION_EOF;
+        $eofPartitionZero->topic_name = 'test-topic';
+        $eofPartitionZero->partition = 0;
+
+        $message = new Message;
+        $message->err = RD_KAFKA_RESP_ERR_NO_ERROR;
+        $message->key = 'key';
+        $message->topic_name = 'test-topic';
+        $message->payload = '{"body": "message payload"}';
+        $message->offset = 0;
+        $message->partition = 1;
+        $message->headers = [];
+
+        $eofPartitionOne = new Message;
+        $eofPartitionOne->err = RD_KAFKA_RESP_ERR__PARTITION_EOF;
+        $eofPartitionOne->topic_name = 'test-topic';
+        $eofPartitionOne->partition = 1;
+
+        $this->mockConsumerWithMessagesAndPartitions(
+            [new TopicPartition('test-topic', 0), new TopicPartition('test-topic', 1)],
+            $eofPartitionZero,
+            $message,
+            $eofPartitionOne,
+        );
+
+        $this->mockProducer();
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            sasl: null,
+            dlq: null,
+            maxMessages: -1,
+            maxCommitRetries: 1,
+            stopAfterLastMessage: true,
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer);
+        $consumer->consume();
+
+        // The EOF on partition 0 must not stop the consumer, since partition 1
+        // still had a message to be consumed at that point.
+        $this->assertSame(1, $consumer->consumedMessagesCount());
+        $this->assertInstanceOf(ConsumedMessage::class, $fakeHandler->lastMessage());
+    }
+
+    #[Test]
+    public function it_marks_a_partition_as_not_drained_when_a_new_message_arrives_after_eof(): void
+    {
+        $fakeHandler = new FakeHandler;
+
+        $eofPartitionZero = new Message;
+        $eofPartitionZero->err = RD_KAFKA_RESP_ERR__PARTITION_EOF;
+        $eofPartitionZero->topic_name = 'test-topic';
+        $eofPartitionZero->partition = 0;
+
+        $messagePartitionZero = new Message;
+        $messagePartitionZero->err = RD_KAFKA_RESP_ERR_NO_ERROR;
+        $messagePartitionZero->key = 'key';
+        $messagePartitionZero->topic_name = 'test-topic';
+        $messagePartitionZero->payload = '{"body": "message payload"}';
+        $messagePartitionZero->offset = 1;
+        $messagePartitionZero->partition = 0;
+        $messagePartitionZero->headers = [];
+
+        $eofPartitionOne = new Message;
+        $eofPartitionOne->err = RD_KAFKA_RESP_ERR__PARTITION_EOF;
+        $eofPartitionOne->topic_name = 'test-topic';
+        $eofPartitionOne->partition = 1;
+
+        $messagePartitionOne = new Message;
+        $messagePartitionOne->err = RD_KAFKA_RESP_ERR_NO_ERROR;
+        $messagePartitionOne->key = 'key';
+        $messagePartitionOne->topic_name = 'test-topic';
+        $messagePartitionOne->payload = '{"body": "message payload"}';
+        $messagePartitionOne->offset = 1;
+        $messagePartitionOne->partition = 1;
+        $messagePartitionOne->headers = [];
+
+        $finalEofPartitionZero = new Message;
+        $finalEofPartitionZero->err = RD_KAFKA_RESP_ERR__PARTITION_EOF;
+        $finalEofPartitionZero->topic_name = 'test-topic';
+        $finalEofPartitionZero->partition = 0;
+
+        $finalEofPartitionOne = new Message;
+        $finalEofPartitionOne->err = RD_KAFKA_RESP_ERR__PARTITION_EOF;
+        $finalEofPartitionOne->topic_name = 'test-topic';
+        $finalEofPartitionOne->partition = 1;
+
+        // Partition 0 reaches EOF but receives a new message afterwards, so the
+        // EOF received for partition 1 alone must not stop the consumer.
+        $this->mockConsumerWithMessagesAndPartitions(
+            [new TopicPartition('test-topic', 0), new TopicPartition('test-topic', 1)],
+            $eofPartitionZero,
+            $messagePartitionZero,
+            $eofPartitionOne,
+            $messagePartitionOne,
+            $finalEofPartitionZero,
+            $finalEofPartitionOne,
+        );
+
+        $this->mockProducer();
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            sasl: null,
+            dlq: null,
+            maxMessages: -1,
+            maxCommitRetries: 1,
+            stopAfterLastMessage: true,
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer);
+        $consumer->consume();
+
+        $this->assertSame(2, $consumer->consumedMessagesCount());
+    }
+
+    #[Test]
+    public function it_stops_consuming_on_timeout_when_stop_after_last_message_is_enabled(): void
+    {
+        $fakeHandler = new FakeHandler;
+
+        $timedOut = new Message;
+        $timedOut->err = RD_KAFKA_RESP_ERR__TIMED_OUT;
+
+        $this->mockConsumerWithMessagesAndPartitions(
+            [new TopicPartition('test-topic', 0), new TopicPartition('test-topic', 1)],
+            $timedOut,
+        );
+
+        $this->mockProducer();
+
+        $config = new Config(
+            broker: 'broker',
+            topics: ['test-topic'],
+            securityProtocol: 'security',
+            commit: 1,
+            groupId: 'group',
+            consumer: $fakeHandler,
+            sasl: null,
+            dlq: null,
+            maxMessages: -1,
+            maxCommitRetries: 1,
+            stopAfterLastMessage: true,
+        );
+
+        $consumer = new Consumer($config, new JsonDeserializer);
+        $consumer->consume();
+
+        $this->assertSame(0, $consumer->consumedMessagesCount());
+        $this->assertNull($fakeHandler->lastMessage());
+    }
+
+    private function mockConsumerWithMessagesAndPartitions(array $partitions, Message ...$messages): void
+    {
+        $mockedKafkaConsumer = m::mock(KafkaConsumer::class)
+            ->shouldReceive('subscribe')
+            ->andReturn(m::self())
+            ->shouldReceive('consume')
+            ->withAnyArgs()
+            ->andReturnUsing(function () use (&$messages) {
+                return array_splice($messages, 0, 1)[0] ?? null;
+            })
+            ->shouldReceive('commit')
+            ->andReturn()
+            ->shouldReceive('getAssignment')
+            ->andReturn($partitions)
+            ->getMock();
+
+        $this->app->bind(KafkaConsumer::class, fn () => $mockedKafkaConsumer);
+    }
+
     private function mockConsumerWithMessageAndPartitions(Message $message, array $partitions): void
     {
         $mockedKafkaConsumer = m::mock(KafkaConsumer::class)


### PR DESCRIPTION
## The Scenario
A consumer is buit with `stopAfterLastMessage()` to drain a topic and exit, a common pattern for scheduled tasks that run periodically, read everything that accumulated since the last run, and stop. The topic has multiple partitions and `enable.partition.eof` enabled in the consumer options, so librdkafka emits a `RD_KAFKA_RESP_ERR__PARTITION_EOF` event whenever the consumer reaches the end of a partition.

## The Problem
`Consumer::handleMessage()` treated any single `PARTITION_EOF` event as "the topic is drained", and immediately requested a stop. However, this event only means that one specific partition has no more messages. On a multi partition topic, whichever partition drained first would shut down the whole consumer while the remaining partitions still had unread messages. In practice, a scheduled run against a 6 partitions topic would process roughly one partition's worth of messages and exit, leaving the rest behind for the next run.

## The Solution
The consumer now trackes EOF state per partition. Each `PARTITION_EOF` event marks its topic + partition as drained, and the consumer only stops once every partition in the current assignment has been marked. Checking against the live assignment returned by `getAssignment()` keeps the logic correct across rebalances. Receiving a regular message from a partition clears its EOF flag, so messages produced while the consumer is still running are handled before stopping.

The existing `RD_KAFKA_RESP_ERR__TIMED_OUT` behavior is unchanged, meaning a timeout still stops the consumer immediately, since it already means nothing was readable on any partition, and it remains the stop signal when `enable.partition.eof` is not set.